### PR TITLE
feat(heredoc): add heredoc, SIGINT, env_variable_exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build/
+obj/
+libft/libft.a
+minishell
+tmp*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 build/
 obj/
+.cache/
 libft/libft.a
 minishell
 tmp*
+compile_commands.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+## 0.1.0 (2025-02-16)
+
+### Feat
+
+- **heredoc**: add heredoc, SIGINT, env_variable_exists
+- **execution**: redirect single builtin
+- **execution**: detect builtins, scaffold runner
+
+### Fix
+
+- **heredoc.c-&-cmd_redir.c**: fix unlink and unclosed FDs with and without SIGINT in heredoc
+- **Norminette-check-OK**: few glitches eliminated
+- **builtins**: pass cmd to builtins
+- **shell**: memory leaks on empty lines & errors

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.10)
+project(minishell LANGUAGES C)
+
+# Automatically find all .c files
+file(GLOB_RECURSE SOURCES src/*.c)
+
+# Add executable
+add_executable(minishell ${SOURCES})
+
+# Generate compile_commands.json
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Enable clang-tidy checks
+set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=-*,misc-unused-parameters;-fix")
+
+# Include directories
+include_directories(inc libft/inc)
+
+# Link libraries
+set(LIBFT_PATH "${CMAKE_SOURCE_DIR}/libft/libft.a")
+
+# Properly link Libft as a static library
+add_library(libft STATIC IMPORTED)
+set_target_properties(libft PROPERTIES IMPORTED_LOCATION ${LIBFT_PATH})
+target_link_libraries(minishell libft readline)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/01/05 17:52:33 by dplotzl           #+#    #+#              #
-#    Updated: 2025/02/12 21:57:25 by xgossing         ###   ########.fr        #
+#    Updated: 2025/02/13 18:08:12 by dplotzl          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -29,10 +29,12 @@ SRC		=	helper/alloc.c \
 			helper/error.c \
 			helper/expander_utils.c \
 			helper/init.c \
+			helper/signal.c \
 			helper/token_utils.c \
 			parsing/cmd_parser.c \
 			parsing/cmd_redir.c \
 			parsing/expander.c \
+			parsing/heredoc.c \
 			parsing/token.c \
 			parsing/tokenizer.c \
 			execution/execute.c \

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/13 18:40:42 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/15 11:06:04 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,8 @@
 # include <sys/types.h>
 # include <sys/wait.h>
 # include <fcntl.h>
+# include <limits.h>
+# include <signal.h>
 # include <sys/stat.h>
 # include <dirent.h>
 # include <stdbool.h>
@@ -157,7 +159,6 @@ bool	env_variable_exists(t_shell *shell, const char *var_name);
 bool	append_char_to_str(t_shell *shell, char **output, int *index, char *c);
 
 // --------------  heredoc  ----------------------------------------------- //
-void	unlink_all_heredocs(void);
 int		handle_heredoc(t_shell *shell, const char *delimiter);
 
 // --------------  init  -------------------------------------------------- //

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/15 11:06:04 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/16 19:40:08 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@
 # include "../libft/inc/libft.h"
 # include "errors.h"
 
-extern sig_atomic_t	g_signal;
+extern volatile sig_atomic_t	g_signal;
 
 typedef enum e_token_type
 {
@@ -165,8 +165,9 @@ int		handle_heredoc(t_shell *shell, const char *delimiter);
 bool	init_shell(t_shell *shell, char **env);
 
 // --------------  signal  ------------------------------------------------ //
-void	handle_signal(int sig);
-void	handle_heredoc_signal(int sig);
+void	handle_sigint(int sig);
+void	handle_heredoc_sigint(int sig);
+void	setup_signals(void (*handler)(int));
 
 // --------------  token  ------------------------------------------------- //
 bool	tokenize(t_shell *shell, t_tok **lst, char *input);

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/12 22:19:20 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/02/13 18:40:42 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,8 @@
 # include <readline/history.h>
 # include "../libft/inc/libft.h"
 # include "errors.h"
+
+extern sig_atomic_t	g_signal;
 
 typedef enum e_token_type
 {
@@ -88,7 +90,7 @@ typedef struct s_tok
 typedef struct s_alloc_tracker
 {
 	void	**allocs;
-	int		*flags;
+	int		*is_array;
 	int		count;
 	int		capacity;
 	bool	initialized;
@@ -151,10 +153,19 @@ bool	expand_dollar_variables(t_shell *shell, char **input);
 
 // --------------  expander_helper  --------------------------------------- //
 int		find_env_variable(t_shell *shell, char *input, int *index);
+bool	env_variable_exists(t_shell *shell, const char *var_name);
 bool	append_char_to_str(t_shell *shell, char **output, int *index, char *c);
+
+// --------------  heredoc  ----------------------------------------------- //
+void	unlink_all_heredocs(void);
+int		handle_heredoc(t_shell *shell, const char *delimiter);
 
 // --------------  init  -------------------------------------------------- //
 bool	init_shell(t_shell *shell, char **env);
+
+// --------------  signal  ------------------------------------------------ //
+void	handle_signal(int sig);
+void	handle_heredoc_signal(int sig);
 
 // --------------  token  ------------------------------------------------- //
 bool	tokenize(t_shell *shell, t_tok **lst, char *input);

--- a/src/helper/alloc.c
+++ b/src/helper/alloc.c
@@ -34,11 +34,11 @@ static bool	alloc_tracker_resize(t_alloc *tracker, int new_capacity)
 		error_exit(NULL, NO_RESIZE, EXIT_FAILURE);
 	}
 	ft_memmove(new_allocs, tracker->allocs, tracker->count * sizeof(void *));
-	ft_memmove(new_flags, tracker->flags, tracker->count * sizeof(int));
+	ft_memmove(new_flags, tracker->is_array, tracker->count * sizeof(int));
 	free(tracker->allocs);
-	free(tracker->flags);
+	free(tracker->is_array);
 	tracker->allocs = new_allocs;
-	tracker->flags = new_flags;
+	tracker->is_array = new_flags;
 	tracker->capacity = new_capacity;
 	return (true);
 }
@@ -60,7 +60,7 @@ void	*alloc_tracker_add(t_alloc *tracker, void *ptr, int is_array)
 			return (NULL);
 	}
 	tracker->allocs[tracker->count] = ptr;
-	tracker->flags[tracker->count] = is_array;
+	tracker->is_array[tracker->count] = is_array;
 	tracker->count++;
 	return (ptr);
 }
@@ -91,7 +91,7 @@ static void	free_tracker_allocs(t_alloc *tracker, int index)
 {
 	char	**array;
 
-	if (tracker->flags[index] == 1)
+	if (tracker->is_array[index] == 1)
 	{
 		array = (char **)tracker->allocs[index];
 		free_array(array);
@@ -117,9 +117,9 @@ void	free_allocs(t_alloc *tracker)
 			free_tracker_allocs(tracker, i);
 	}
 	free(tracker->allocs);
-	free(tracker->flags);
+	free(tracker->is_array);
 	tracker->allocs = NULL;
-	tracker->flags = NULL;
+	tracker->is_array = NULL;
 	tracker->count = 0;
 	tracker->capacity = 0;
 	tracker->initialized = false;

--- a/src/helper/expander_utils.c
+++ b/src/helper/expander_utils.c
@@ -12,17 +12,32 @@
 
 #include "minishell.h"
 
+/*
+**	Identify the end of an environment variable
+*/
+
 static int	end_env_var(char *var_name, char *env_entry)
 {
-	int	i;
+	int		i;
+	char	*equal_sign;
 
 	i = 0;
 	while (var_name[i] && (ft_isalnum(var_name[i]) || var_name[i] == '_'))
 		++i;
-	if (ft_strchr(env_entry, '=') - env_entry == i)
+	equal_sign = ft_strchr(env_entry, '=');
+	if (!equal_sign)
+		return (0);
+	if (equal_sign - env_entry == i)
 		return (i);
 	return (0);
 }
+
+/*
+**	Find an environment variable in the list:
+**	- Return 0 if the variable does not exist
+**	- Return 1 if the variable is found
+**	- Return 2 if the variable is $?
+*/
 
 int	find_env_variable(t_shell *shell, char *input, int *index)
 {
@@ -44,9 +59,46 @@ int	find_env_variable(t_shell *shell, char *input, int *index)
 			return (1);
 		}
 		node = node->next;
+		if (node == shell->env)
+			break ;
 	}
 	return (0);
 }
+
+/*
+**	Check if an environment variable exists
+*/
+
+bool	env_variable_exists(t_shell *shell, const char *var_name)
+{
+	t_env	*node;
+	size_t	len;
+	size_t	data_len;
+
+	if (!var_name || !*var_name || !shell->env)
+		return (false);
+	len = 0;
+	while (var_name[len] && (ft_isalnum(var_name[len]) || var_name[len] == '_'))
+		len++;
+	node = shell->env;
+	while (node)
+	{
+		data_len = ft_strlen(node->data);
+		if (data_len >= len && ft_strncmp(node->data, var_name, len) == 0)
+		{
+			if ((data_len == len) || (node->data[len] == '='))
+				return (true);
+		}
+		node = node->next;
+		if (node == shell->env)
+			break ;
+	}
+	return (false);
+}
+
+/*
+**	Append a character to a string
+*/
 
 bool	append_char_to_str(t_shell *shell, char **output, int *index, char *c)
 {

--- a/src/helper/init.c
+++ b/src/helper/init.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/04 12:12:50 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/07 13:27:16 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/13 15:22:34 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,13 +28,13 @@ static bool	init_alloc_tracker(t_shell *shell, char **env)
 	if (!shell || initial_capacity <= 0)
 		return (false);
 	shell->alloc_tracker.allocs = ft_calloc(initial_capacity, sizeof(void *));
-	shell->alloc_tracker.flags = ft_calloc(initial_capacity, sizeof(int));
-	if (!shell->alloc_tracker.allocs || !shell->alloc_tracker.flags)
+	shell->alloc_tracker.is_array = ft_calloc(initial_capacity, sizeof(int));
+	if (!shell->alloc_tracker.allocs || !shell->alloc_tracker.is_array)
 	{
 		free(shell->alloc_tracker.allocs);
-		free(shell->alloc_tracker.flags);
+		free(shell->alloc_tracker.is_array);
 		shell->alloc_tracker.allocs = NULL;
-		shell->alloc_tracker.flags = NULL;
+		shell->alloc_tracker.is_array = NULL;
 		error_exit(shell, NO_ALLOC, EXIT_FAILURE);
 	}
 	shell->alloc_tracker.count = 0;

--- a/src/helper/signal.c
+++ b/src/helper/signal.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 10:47:06 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/13 21:04:28 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/15 11:06:04 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,6 +40,5 @@ void	handle_heredoc_signal(int sig)
 	{
 		g_signal = 1;
 		write(1, "\n", 1);
-		unlink_all_heredocs();
 	}
 }

--- a/src/helper/signal.c
+++ b/src/helper/signal.c
@@ -1,0 +1,46 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   signal.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/22 10:47:06 by dplotzl           #+#    #+#             */
+/*   Updated: 2025/02/13 18:13:47 by dplotzl          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+sig_atomic_t	g_signal = 0;
+
+/*
+**	Signal handler for regular signals (SIGINT)
+*/
+
+void	handle_signal(int sig)
+{
+	if (sig == SIGINT)
+	{
+		g_signal = 1;
+		write(1, "\n", 1);
+		rl_replace_line("", 0);
+		rl_on_new_line();
+		rl_redisplay();
+	}
+}
+
+/*
+**	Signal handler for heredoc signals (SIGINT)
+*/
+
+void	handle_heredoc_signal(int sig)
+{
+	if (sig == SIGINT)
+	{
+		g_signal = 1;
+		write(1, "\n", 1);
+		unlink_all_heredocs();
+	}
+}
+

--- a/src/helper/signal.c
+++ b/src/helper/signal.c
@@ -6,19 +6,19 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 10:47:06 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/15 11:06:04 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/16 19:40:08 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-sig_atomic_t	g_signal = 0;
+volatile sig_atomic_t	g_signal = 0;
 
 /*
 **	Signal handler for regular signals (SIGINT)
 */
 
-void	handle_signal(int sig)
+void	handle_sigint(int sig)
 {
 	if (sig == SIGINT)
 	{
@@ -34,11 +34,27 @@ void	handle_signal(int sig)
 **	Signal handler for heredoc signals (SIGINT)
 */
 
-void	handle_heredoc_signal(int sig)
+void	handle_heredoc_sigint(int sig)
 {
 	if (sig == SIGINT)
 	{
 		g_signal = 1;
 		write(1, "\n", 1);
 	}
+}
+
+/*
+**	Set up signal handlers for SIGINT and SIGQUIT (which is ignored)
+*/
+
+void	setup_signals(void (*handler)(int))
+{
+	struct sigaction	sa;
+
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
+	sa.sa_handler = handler;
+	sigaction(SIGINT, &sa, NULL);
+	sa.sa_handler = SIG_IGN;
+	sigaction(SIGQUIT, &sa, NULL);
 }

--- a/src/helper/signal.c
+++ b/src/helper/signal.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 10:47:06 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/13 18:13:47 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/13 21:04:28 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,4 +43,3 @@ void	handle_heredoc_signal(int sig)
 		unlink_all_heredocs();
 	}
 }
-

--- a/src/main.c
+++ b/src/main.c
@@ -6,11 +6,15 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:48:13 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/13 23:10:22 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/16 19:44:47 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+/*
+**	Advances the pointer to the next non-whitespace character
+*/
 
 static bool	blank_line(char *input)
 {
@@ -29,8 +33,10 @@ static bool	blank_line(char *input)
 
 static void	minishell(t_shell *shell)
 {
+	setup_signals(handle_sigint);
 	while (1)
 	{
+		g_signal = 0;
 		shell->cmd_input = readline(shell->prompt);
 		if (!shell->cmd_input)
 			break ;

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:48:13 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/12 21:43:20 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/02/13 19:02:12 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,7 +31,9 @@ static void	minishell(t_shell *shell)
 {
 	while (1)
 	{
-		shell->cmd_input = readline(shell->prompt); // we should probably add this to the alloc_tracker, might leak if we exit() somewhere
+		shell->cmd_input = readline(shell->prompt);
+		// When we add alloc_tracker_add for readline here, we get double free
+		// when exiting.
 		if (!shell->cmd_input)
 			break ;
 		if (blank_line(shell->cmd_input))

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:48:13 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/13 19:02:12 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/13 23:10:22 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,8 +32,6 @@ static void	minishell(t_shell *shell)
 	while (1)
 	{
 		shell->cmd_input = readline(shell->prompt);
-		// When we add alloc_tracker_add for readline here, we get double free
-		// when exiting.
 		if (!shell->cmd_input)
 			break ;
 		if (blank_line(shell->cmd_input))

--- a/src/parsing/cmd_parser.c
+++ b/src/parsing/cmd_parser.c
@@ -13,7 +13,32 @@
 #include "minishell.h"
 
 /*
-**	Add an argument to the command
+**	Count the number of arguments in the command to determine how much memory
+**	to allocate for the args array.
+*/
+
+static int	count_args(t_shell *shell, t_tok *token)
+{
+	t_tok	*current;
+	int		i;
+
+	i = 0;
+	current = token;
+	if (current->type == CMD || (current->type == ARG
+			&& current->prev->type != PIPE))
+		i++;
+	current = current->next;
+	while (current != shell->tokens && current->type != PIPE)
+	{
+		if (current->type == CMD || current->type == ARG)
+			i++;
+		current = current->next;
+	}
+	return (i);
+}
+
+/*
+**	Add an argument to the command's argument list
 */
 
 static void	add_arg(t_shell *shell, char **args, int *i, char *content)
@@ -25,7 +50,7 @@ static void	add_arg(t_shell *shell, char **args, int *i, char *content)
 }
 
 /*
-**	Check if the argument is valid
+**	Check if a token is a valid command argument
 */
 
 static bool	is_valid_arg(t_shell *shell, t_tok *current)
@@ -40,34 +65,10 @@ static bool	is_valid_arg(t_shell *shell, t_tok *current)
 }
 
 /*
-**	Count the number of arguments in the command
+**	Extract arguments from the token list and store them in an array
 */
 
-static int	count_args(t_shell *shell, t_tok *token)
-{
-	t_tok	*current;
-	int		i;
-
-	i = 0;
-	current = token;
-	if (current->type == CMD || (current->type == ARG \
-			&& current->prev->type != PIPE))
-		i++;
-	current = current->next;
-	while (current != shell->tokens && current->type != PIPE)
-	{
-		if (current->type == CMD || current->type == ARG)
-			i++;
-		current = current->next;
-	}
-	return (i);
-}
-
-/*
-**	Get the arguments of the command
-*/
-
-static char	**populate_args(t_shell *shell, t_tok *token)
+static char	**extract_args(t_shell *shell, t_tok *token)
 {
 	t_tok	*current;
 	char	**args;
@@ -94,7 +95,10 @@ static char	**populate_args(t_shell *shell, t_tok *token)
 }
 
 /*
-**	Main command parsing function
+**	Convert tokenized input into a command list and handle redirections
+**	before execution.
+**	- First iteration: !shell->cmd keeps loop running
+**	- Subsequent iterations: loop continues as long as current != shell->tokens
 */
 
 bool	parse_commands(t_shell *shell)
@@ -117,7 +121,7 @@ bool	parse_commands(t_shell *shell)
 				shell->status = 42;
 				return (false);
 			}
-			cmd->args = populate_args(shell, current);
+			cmd->args = extract_args(shell, current);
 			if (!cmd->args)
 				return (error(NO_MEM, false));
 		}

--- a/src/parsing/cmd_redir.c
+++ b/src/parsing/cmd_redir.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/06 23:19:30 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/13 18:41:28 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/13 21:02:14 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,8 +40,8 @@ static int	open_file(t_shell *shell, char *file, t_t_typ type)
 		flags = O_WRONLY | O_CREAT | O_APPEND;
 	else if (type == REDIR_IN)
 		flags = O_RDONLY;
-	else if (type == HEREDOC) 
-	 	return (handle_heredoc(shell, file));
+	else if (type == HEREDOC)
+		return (handle_heredoc(shell, file));
 	else
 		flags = 0;
 	fd = open(file, flags, 0644);
@@ -68,7 +68,6 @@ static bool	process_redirection(t_shell *shell, t_cmd *cmd, t_tok *token)
 		close(*fd);
 		*fd = -2;
 	}
-	// should we reset fd to -2 here? -> Oh yes, done!
 	if (!token->next || is_operator_token(token))
 		return (false);
 	*fd = open_file(shell, token->next->content, token->type);

--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 20:37:00 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/13 15:26:58 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/13 21:03:37 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,7 +67,8 @@ static bool	expand_exit_status(t_shell *shell, char **output)
 **	- If the character after the $ is a letter, ? or _, check if it's a variable
 */
 
-static bool	should_expand_dollar(t_shell *shell, const char *input, int i, bool s_quote)
+static bool	should_expand_dollar(t_shell *shell, const char *input, int i,
+									bool s_quote)
 {
 	if (!input[i] || input[i] != '$' || s_quote)
 		return (false);

--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -6,14 +6,14 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 20:37:00 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/07 13:56:18 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/13 15:26:58 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
 /*
-**	Expands the environment expand_dollar_variables
+**	Expands a given environment variable ($VAR) by replacing it with its value.
 */
 
 static bool	expand_env_var(t_shell *shell, char **output, char *var, int len)
@@ -42,7 +42,7 @@ static bool	expand_env_var(t_shell *shell, char **output, char *var, int len)
 }
 
 /*
-**	Expands the exit status
+**	Expands $?, replacing it with the exit status of the last command.
 */
 
 static bool	expand_exit_status(t_shell *shell, char **output)
@@ -61,21 +61,30 @@ static bool	expand_exit_status(t_shell *shell, char **output)
 }
 
 /*
-**	Helper to check if the dollar sign should be expanded
+**	Helper to check if the dollar sign should trigger variable expansion:
+**	- If the character before the $ is alphanumeric, it's not a variable
+**	- If the character after the $ is not a letter, ?, or _, it's not a variable
+**	- If the character after the $ is a letter, ? or _, check if it's a variable
 */
 
-static bool	should_expand_dollar(const char *input, int i, bool s_quote)
+static bool	should_expand_dollar(t_shell *shell, const char *input, int i, bool s_quote)
 {
 	if (!input[i] || input[i] != '$' || s_quote)
 		return (false);
+	if (i > 0 && ft_isalnum(input[i - 1]))
+		return (false);
 	if (input[i + 1] && (ft_isalpha(input[i + 1]) || input[i + 1] == '?'
 			|| input[i + 1] == '_'))
-		return (true);
-	return (false);
+		return (false);
+	if (input[i + 1] != '?' && !env_variable_exists(shell, &input[i + 1]))
+		return (false);
+	return (true);
 }
 
 /*
-**	Handles the expansion of the dollar sign
+**	Handles expanding a $-variable found in the input string:
+**	- If result == 1 -> expand the environment variable
+**	- If result == 2 -> expand the exit status
 */
 
 static bool	handle_expansion(t_shell *shell, char **output, char *input,
@@ -95,14 +104,12 @@ static bool	handle_expansion(t_shell *shell, char **output, char *input,
 		return (expand_exit_status(shell, output));
 	}
 	(*index)++;
-	while ((input[*index]) && (ft_isalnum(input[*index])
-			|| input[*index] == '_'))
-		(*index)++;
 	return (true);
 }
 
 /*
-**	Expands the dollar sign variables
+**	Expands all $-variables in the user input. Allows dynamic substitition
+**	of environment variables before command execution.
 */
 
 bool	expand_dollar_variables(t_shell *shell, char **input)
@@ -121,7 +128,7 @@ bool	expand_dollar_variables(t_shell *shell, char **input)
 	while ((*input)[i])
 	{
 		update_quote_state(&d_quote, &s_quote, (*input)[i]);
-		if (should_expand_dollar(*input, i, s_quote))
+		if (should_expand_dollar(shell, *input, i, s_quote))
 		{
 			if (!handle_expansion(shell, &output, *input, &i))
 				return (false);

--- a/src/parsing/heredoc.c
+++ b/src/parsing/heredoc.c
@@ -6,39 +6,11 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/13 16:06:25 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/13 18:27:37 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/15 12:46:01 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-
-/*
-**	Delete all active heredocs when Ctrl+C is pressed.
-**	Prevents leftover heredoc files in /tmp/ and ensures that
-**	all heredocs closed at once.
-*/
-
-void	unlink_all_heredocs(void)
-{
-	DIR				*dir;
-	struct dirent	*entry;
-	char			*filepath;
-
-	dir = opendir("/tmp");
-	if (!dir)
-		return ;
-	entry = readdir(dir);
-	while (entry)
-	{
-		if (ft_strncmp(entry->d_name, ".heredoc_", 9) == 0)
-		{
-			filepath = safe_strjoin(NULL, "/tmp/", entry->d_name);
-			unlink(filepath);
-		}
-		entry = readdir(dir);
-	}
-	closedir(dir);
-}
 
 /*
 **	Read user input into heredoc_filename until the delimiter is found
@@ -55,6 +27,7 @@ static bool	heredoc_read_input(t_shell *shell, int fd, const char *delimiter)
 	while (!g_signal)
 	{
 		line = readline("> ");
+		alloc_tracker_add(&shell->alloc_tracker, line, 0);
 		if (!line)
 		{
 			ft_putstr_fd("minishell: heredoc delimited by EOF (needs `", 2);
@@ -62,47 +35,46 @@ static bool	heredoc_read_input(t_shell *shell, int fd, const char *delimiter)
 			ft_putendl_fd("')", 2);
 			break ;
 		}
-		alloc_tracker_add(&shell->alloc_tracker, line, 0);
 		if (ft_strcmp(line, delimiter) == 0)
 			break ;
 		ft_putendl_fd(line, fd);
 	}
-	close(fd);
 	signal(SIGINT, handle_signal);
 	return (!g_signal);
 }
 
 /*
 **	Handle heredoc redirection:
-**	1. Create unique filename per heredoc so each shell has its own heredoc.
-**	2. Set custom signal handler for heredoc 
-**	3. Read user input into the file until the delimiter is found or Ctrl+C.
-**	4. Restore the default signal handler.
-**	5. Open the temporary file for reading.
-**	6. Unlink the temporary file.
-**	7. Return the file descriptor for input redirection.
+**	1. Create unique filename per heredoc for cases like:
+**		cat << EOF1 | grep hello << EOF2
+**	(not sure if necessary to handle this, open to suggestions)
 */
 
 int	handle_heredoc(t_shell *shell, const char *delimiter)
 {
-	int		fd;
-	char	*pid_str;
-	char	*heredoc_filename;
+	int			fd;
+	char		*count_str;
+	char		*heredoc_filename;
+	static int	heredoc_count = 0;
 
-	pid_str = ft_itoa(getpid());
-	alloc_tracker_add(&shell->alloc_tracker, pid_str, 0);
-	heredoc_filename = safe_strjoin(shell, "/tmp/.heredoc_", pid_str);
+	count_str = ft_itoa(heredoc_count++);
+	alloc_tracker_add(&shell->alloc_tracker, count_str, 0);
+	heredoc_filename = safe_strjoin(shell, "./.heredoc_", count_str);
 	fd = open(heredoc_filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
 	if (fd == -1)
-		return (perror("heredoc"), -1);
+		return (-1);
 	if (!heredoc_read_input(shell, fd, delimiter))
 	{
+		if (fd >= 3)
+			close(fd);
 		unlink(heredoc_filename);
 		signal(SIGINT, handle_signal);
 		return (-1);
 	}
+	close(fd);
 	fd = open(heredoc_filename, O_RDONLY);
 	if (fd > 0)
 		unlink(heredoc_filename);
+	signal(SIGINT, handle_signal);
 	return (fd);
 }

--- a/src/parsing/heredoc.c
+++ b/src/parsing/heredoc.c
@@ -6,42 +6,56 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/13 16:06:25 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/15 12:46:01 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/16 19:48:14 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
 /*
-**	Read user input into heredoc_filename until the delimiter is found
-**	or Ctrl+C (SIGINT) is pressed. Ctrl+C sets g_signal to 1.
+**	Print warning message when EOF is reached before delimiter,
+**	imitating original bash behavior.
+*/
+
+static void	print_eof_warning(int line_count, const char *delimiter)
+{
+	ft_putstr_fd("minishell: warning: here-document at line ", 2);
+	ft_putnbr_fd(line_count, 2);
+	ft_putstr_fd(" delimited by end-of-file (wanted `", 2);
+	ft_putstr_fd((char *)delimiter, 2);
+	ft_putendl_fd("')", 2);
+}
+
+/*
+**	Read user input into heredoc_filename until the delimiter is found,
+**	Ctrl+D (EOF) or Ctrl+C (SIGINT) is pressed. Ctrl+C sets g_signal to 1.
 */
 
 static bool	heredoc_read_input(t_shell *shell, int fd, const char *delimiter)
 {
 	char	*line;
+	int		line_count;
 
-	line = NULL;
 	g_signal = 0;
-	signal(SIGINT, handle_heredoc_signal);
+	setup_signals(handle_heredoc_sigint);
+	line_count = 0;
 	while (!g_signal)
 	{
 		line = readline("> ");
 		alloc_tracker_add(&shell->alloc_tracker, line, 0);
+		line_count++;
 		if (!line)
 		{
-			ft_putstr_fd("minishell: heredoc delimited by EOF (needs `", 2);
-			ft_putstr_fd((char *)delimiter, 2);
-			ft_putendl_fd("')", 2);
+			print_eof_warning(line_count, delimiter);
 			break ;
 		}
 		if (ft_strcmp(line, delimiter) == 0)
 			break ;
 		ft_putendl_fd(line, fd);
 	}
-	signal(SIGINT, handle_signal);
+	setup_signals(handle_sigint);
 	return (!g_signal);
-}
+	}
 
 /*
 **	Handle heredoc redirection:
@@ -68,13 +82,13 @@ int	handle_heredoc(t_shell *shell, const char *delimiter)
 		if (fd >= 3)
 			close(fd);
 		unlink(heredoc_filename);
-		signal(SIGINT, handle_signal);
+		g_signal = 0;
+		setup_signals(handle_sigint);
 		return (-1);
 	}
 	close(fd);
 	fd = open(heredoc_filename, O_RDONLY);
 	if (fd > 0)
 		unlink(heredoc_filename);
-	signal(SIGINT, handle_signal);
 	return (fd);
 }

--- a/src/parsing/heredoc.c
+++ b/src/parsing/heredoc.c
@@ -1,0 +1,108 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   heredoc.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/02/13 16:06:25 by dplotzl           #+#    #+#             */
+/*   Updated: 2025/02/13 18:27:37 by dplotzl          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+/*
+**	Delete all active heredocs when Ctrl+C is pressed.
+**	Prevents leftover heredoc files in /tmp/ and ensures that
+**	all heredocs closed at once.
+*/
+
+void	unlink_all_heredocs(void)
+{
+	DIR				*dir;
+	struct dirent	*entry;
+	char			*filepath;
+
+	dir = opendir("/tmp");
+	if (!dir)
+		return ;
+	entry = readdir(dir);
+	while (entry)
+	{
+		if (ft_strncmp(entry->d_name, ".heredoc_", 9) == 0)
+		{
+			filepath = safe_strjoin(NULL, "/tmp/", entry->d_name);
+			unlink(filepath);
+		}
+		entry = readdir(dir);
+	}
+	closedir(dir);
+}
+
+/*
+**	Read user input into heredoc_filename until the delimiter is found
+**	or Ctrl+C (SIGINT) is pressed. Ctrl+C sets g_signal to 1.
+*/
+
+static bool	heredoc_read_input(t_shell *shell, int fd, const char *delimiter)
+{
+	char	*line;
+
+	line = NULL;
+	g_signal = 0;
+	signal(SIGINT, handle_heredoc_signal);
+	while (!g_signal)
+	{
+		line = readline("> ");
+		if (!line)
+		{
+			ft_putstr_fd("minishell: heredoc delimited by EOF (needs `", 2);
+			ft_putstr_fd((char *)delimiter, 2);
+			ft_putendl_fd("')", 2);
+			break ;
+		}
+		alloc_tracker_add(&shell->alloc_tracker, line, 0);
+		if (ft_strcmp(line, delimiter) == 0)
+			break ;
+		ft_putendl_fd(line, fd);
+	}
+	close(fd);
+	signal(SIGINT, handle_signal);
+	return (!g_signal);
+}
+
+/*
+**	Handle heredoc redirection:
+**	1. Create unique filename per heredoc so each shell has its own heredoc.
+**	2. Set custom signal handler for heredoc 
+**	3. Read user input into the file until the delimiter is found or Ctrl+C.
+**	4. Restore the default signal handler.
+**	5. Open the temporary file for reading.
+**	6. Unlink the temporary file.
+**	7. Return the file descriptor for input redirection.
+*/
+
+int	handle_heredoc(t_shell *shell, const char *delimiter)
+{
+	int		fd;
+	char	*pid_str;
+	char	*heredoc_filename;
+
+	pid_str = ft_itoa(getpid());
+	alloc_tracker_add(&shell->alloc_tracker, pid_str, 0);
+	heredoc_filename = safe_strjoin(shell, "/tmp/.heredoc_", pid_str);
+	fd = open(heredoc_filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if (fd == -1)
+		return (perror("heredoc"), -1);
+	if (!heredoc_read_input(shell, fd, delimiter))
+	{
+		unlink(heredoc_filename);
+		signal(SIGINT, handle_signal);
+		return (-1);
+	}
+	fd = open(heredoc_filename, O_RDONLY);
+	if (fd > 0)
+		unlink(heredoc_filename);
+	return (fd);
+}

--- a/src/parsing/token.c
+++ b/src/parsing/token.c
@@ -103,8 +103,8 @@ static bool	validate_pipe_syntax(t_tok *prev_token, t_tok **lst)
 }
 
 /*
-**	Tokenize the input string and create a linked list of tokens,
-**	checking for pipe syntax errors
+**	Core function for breaking user input into structured tokens.
+**	Also checking for pipe syntax errors.
 */
 
 bool	tokenize(t_shell *shell, t_tok **lst, char *input)

--- a/src/parsing/tokenizer.c
+++ b/src/parsing/tokenizer.c
@@ -97,7 +97,8 @@ static bool	check_unclosed_quotes(t_shell *shell, const char *input)
 
 /*
 **	Checks first for invalid syntax and unclosed quotes,
-**	then expands dollar variables, tokenizes the input and parses the commands.
+**	then handles environemnt variable expansion, tokenizes the input
+**	and parses the commands.
 */
 
 bool	tokenize_input(t_shell *shell, char *input)

--- a/suppression.txt
+++ b/suppression.txt
@@ -1,0 +1,12 @@
+{
+    leak readline
+    Memcheck:Leak 
+    ...
+    fun:readline
+}
+{
+    leak add_history
+    Memcheck:Leak
+    ...
+    fun:add_history
+}


### PR DESCRIPTION
This pull request includes several changes to the `minishell` project, focusing on setting up CMake, adding new features, and improving code clarity and functionality. The most important changes include the addition of a CMake build configuration, modifications to the signal handling, and updates to the allocation tracker and environment variable handling.

### Build System:
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR1-R25): Added a new CMake configuration file to set up the project, automatically find `.c` files, add the executable, generate `compile_commands.json`, enable clang-tidy checks, include directories, and link libraries.

### Signal Handling:
* [`inc/minishell.h`](diffhunk://#diff-71ac2db5fec65368c16ab9fc572b50749d817e528958ff7471446e3ece847671R33-R34): Added a new global variable `g_signal` and declared signal handling functions. [[1]](diffhunk://#diff-71ac2db5fec65368c16ab9fc572b50749d817e528958ff7471446e3ece847671R33-R34) [[2]](diffhunk://#diff-71ac2db5fec65368c16ab9fc572b50749d817e528958ff7471446e3ece847671R156-R169)
* [`src/helper/signal.c`](diffhunk://#diff-62bc3765a39df3f071f1a7a7c024e8e8f73b1b96c50f75bbb7eddbb28c9407e1R1-R46): Implemented signal handlers for regular signals (SIGINT) and heredoc signals.

### Allocation Tracker:
* Updated the allocation tracker to use `is_array` instead of `flags` for better clarity and consistency across multiple files, including `inc/minishell.h`, `src/helper/alloc.c`, and `src/helper/init.c`. [[1]](diffhunk://#diff-71ac2db5fec65368c16ab9fc572b50749d817e528958ff7471446e3ece847671L91-R93) [[2]](diffhunk://#diff-2ae869cc63d7e13504b80bd20f9a6001ffac2bf2ca25bdc9149a62ce30463e9aL37-R41) [[3]](diffhunk://#diff-7d751a8b8b2019ef57359a63f034857ab6dbc98b94cdfb30df859f1fb60237bdL31-R37)

### Environment Variable Handling:
* [`src/helper/expander_utils.c`](diffhunk://#diff-54f948ca3b8deb95103528d93ea376c828a55705f7753ed720bcc00959c05505R62-R102): Added a new function `env_variable_exists` to check if an environment variable exists and improved the `find_env_variable` function. (F6c26316L6R6, [src/helper/expander_utils.cR62-R102](diffhunk://#diff-54f948ca3b8deb95103528d93ea376c828a55705f7753ed720bcc00959c05505R62-R102))

### Command Parsing:
* [`src/parsing/cmd_parser.c`](diffhunk://#diff-ef3c15648da97ea93bc9b88b8eda454b9c38b1096c087aa4ed5cde6ef193c475L16-R41): Refactored functions to improve clarity, including renaming `populate_args` to `extract_args` and adding a new function `count_args`. [[1]](diffhunk://#diff-ef3c15648da97ea93bc9b88b8eda454b9c38b1096c087aa4ed5cde6ef193c475L16-R41) [[2]](diffhunk://#diff-ef3c15648da97ea93bc9b88b8eda454b9c38b1096c087aa4ed5cde6ef193c475L28-R53) [[3]](diffhunk://#diff-ef3c15648da97ea93bc9b88b8eda454b9c38b1096c087aa4ed5cde6ef193c475L43-R71) [[4]](diffhunk://#diff-ef3c15648da97ea93bc9b88b8eda454b9c38b1096c087aa4ed5cde6ef193c475L97-R101) [[5]](diffhunk://#diff-ef3c15648da97ea93bc9b88b8eda454b9c38b1096c087aa4ed5cde6ef193c475L120-R124)

These changes enhance the overall structure and functionality of the `minishell` project, making it more maintainable and robust.