### PR TITLE
fix(expander.c,-expander_utils.c): fix variable expansion, correct ha…

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/19 19:05:48 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/19 19:37:46 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -114,10 +114,7 @@ typedef struct s_shell
 	char	*user;			// User name
 }	t_shell;
 
-typedef struct s_expander
-{
-	bool	(*fn)(t_shell *shell, char **output, char *input, int *index);
-}	t_expander;
+typedef bool	(*t_expander)(t_shell *shell, char **output, char *input, int *index);
 
 typedef struct s_builtin
 {

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/16 19:40:08 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/19 19:05:48 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -114,6 +114,11 @@ typedef struct s_shell
 	char	*user;			// User name
 }	t_shell;
 
+typedef struct s_expander
+{
+	bool	(*fn)(t_shell *shell, char **output, char *input, int *index);
+}	t_expander;
+
 typedef struct s_builtin
 {
 	t_b_typ	type;
@@ -153,9 +158,9 @@ void	clean_shell(t_shell *shell);
 // --------------  expander  ---------------------------------------------- //
 bool	expand_dollar_variables(t_shell *shell, char **input);
 
-// --------------  expander_helper  --------------------------------------- //
-int		find_env_variable(t_shell *shell, char *input, int *index);
-bool	env_variable_exists(t_shell *shell, const char *var_name);
+// --------------  expander_utils  ---------------------------------------- //
+int		find_or_check_env(t_shell *shell, char *input, int *index, bool check);
+int		match_env_variable(char *var_name, char *env_entry);
 bool	append_char_to_str(t_shell *shell, char **output, int *index, char *c);
 
 // --------------  heredoc  ----------------------------------------------- //

--- a/src/helper/expander_utils.c
+++ b/src/helper/expander_utils.c
@@ -6,94 +6,66 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 20:39:27 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/06 14:35:37 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/19 18:00:19 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
 /*
-**	Identify the end of an environment variable
+**	Check if var_name matches the name of an environment variable inside
+**	env_entry and returns its length if it does.
 */
 
-static int	end_env_var(char *var_name, char *env_entry)
+int	match_env_variable(char *var_name, char *env_entry)
 {
-	int		i;
-	char	*equal_sign;
+	int	i;
 
-	i = 0;
-	while (var_name[i] && (ft_isalnum(var_name[i]) || var_name[i] == '_'))
-		++i;
-	equal_sign = ft_strchr(env_entry, '=');
-	if (!equal_sign)
-		return (0);
-	if (equal_sign - env_entry == i)
+	i = -1;
+	while (var_name[++i] && (ft_isalnum(var_name[i]) || var_name[i] == '_'))
+	{
+		if (var_name[i] != env_entry[i])
+			return (0);
+	}
+	if (env_entry[i] == '=')
 		return (i);
 	return (0);
 }
 
 /*
-**	Find an environment variable in the list:
-**	- Return 0 if the variable does not exist
-**	- Return 1 if the variable is found
-**	- Return 2 if the variable is $?
+**	Find an environment variable in the list or check if it exists:
+**	- If check == true:
+**		- Return 0 if the variable does not exist
+**		- Return 1 if the variable is found
+**	- If check == false:
+**		- Return 0 if the variable does not exist
+**		- Return 1 if the variable is found
+**		- Return 2 if the variable is $?
 */
 
-int	find_env_variable(t_shell *shell, char *input, int *index)
+int	find_or_check_env(t_shell *shell, char *input, int *index, bool check)
 {
 	t_env	*node;
 	int		len;
 
-	if (!input || !input[*index])
+	if (!shell->env || !input || (check && !*input))
 		return (0);
-	if (input[*index + 1] == '?')
+	if (!check && input[*index] == '$' && input[*index + 1] == '?')
 		return (2);
 	node = shell->env;
 	while (node)
 	{
-		len = end_env_var(&input[*index + 1], node->data);
-		if (len > 0 && ft_strncmp(node->data, &input[*index + 1], len) == 0
-			&& node->data[len] == '=')
-		{
-			*index += len + 1;
+		if (check)
+			len = match_env_variable(input, node->data);
+		else
+			len = match_env_variable(&input[*index + 1], node->data);
+		if (len > 0)
 			return (1);
-		}
 		node = node->next;
 		if (node == shell->env)
 			break ;
 	}
 	return (0);
-}
-
-/*
-**	Check if an environment variable exists
-*/
-
-bool	env_variable_exists(t_shell *shell, const char *var_name)
-{
-	t_env	*node;
-	size_t	len;
-	size_t	data_len;
-
-	if (!var_name || !*var_name || !shell->env)
-		return (false);
-	len = 0;
-	while (var_name[len] && (ft_isalnum(var_name[len]) || var_name[len] == '_'))
-		len++;
-	node = shell->env;
-	while (node)
-	{
-		data_len = ft_strlen(node->data);
-		if (data_len >= len && ft_strncmp(node->data, var_name, len) == 0)
-		{
-			if ((data_len == len) || (node->data[len] == '='))
-				return (true);
-		}
-		node = node->next;
-		if (node == shell->env)
-			break ;
-	}
-	return (false);
 }
 
 /*

--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 20:37:00 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/19 19:03:50 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/19 19:38:40 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,11 +80,11 @@ static bool	handle_expansion(t_shell *shell, char **output, char *input,
 
 	if (!input)
 		return (false);
-	expander[0].fn = expand_env_variable;
-	expander[1].fn = expand_exit_status;
+	expander[0] = expand_env_variable;
+	expander[1] = expand_exit_status;
 	result = find_or_check_env(shell, input, index, false);
 	if (result == 1 || result == 2)
-		return (expander[result - 1].fn(shell, output, &input[*index + 1],
+		return (expander[result - 1](shell, output, &input[*index + 1],
 				index));
 	return (true);
 }

--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 20:37:00 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/13 21:03:37 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/19 19:03:50 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,28 +16,30 @@
 **	Expands a given environment variable ($VAR) by replacing it with its value.
 */
 
-static bool	expand_env_var(t_shell *shell, char **output, char *var, int len)
+static bool	expand_env_variable(t_shell *shell, char **output, char *input,
+							int *index)
 {
 	t_env	*node;
 	char	*var_value;
 	char	*new_output;
+	int		len;
 
 	node = shell->env;
 	while (node)
 	{
-		if (ft_strncmp(node->data, var, len) == 0 && node->data[len] == '=')
+		len = match_env_variable(input, node->data);
+		if (len > 0)
 		{
 			var_value = node->data + len + 1;
-			break ;
+			new_output = safe_strjoin(shell, *output, var_value);
+			if (!new_output)
+				return (error(NO_MEM, false));
+			*output = new_output;
+			*index += len + 1;
+			return (true);
 		}
 		node = node->next;
 	}
-	if (!node)
-		return (true);
-	new_output = safe_strjoin(shell, *output, var_value);
-	if (!new_output)
-		return (error(NO_MEM, false));
-	*output = new_output;
 	return (true);
 }
 
@@ -45,11 +47,13 @@ static bool	expand_env_var(t_shell *shell, char **output, char *var, int len)
 **	Expands $?, replacing it with the exit status of the last command.
 */
 
-static bool	expand_exit_status(t_shell *shell, char **output)
+static bool	expand_exit_status(t_shell *shell, char **output, char *input,
+								int *index)
 {
 	char	*status_str;
 	char	*new_str;
 
+	(void)input;
 	status_str = ft_itoa(shell->status);
 	if (!status_str || !alloc_tracker_add(&shell->alloc_tracker, status_str, 0))
 		return (error(NO_MEM, false));
@@ -57,54 +61,56 @@ static bool	expand_exit_status(t_shell *shell, char **output)
 	if (!new_str)
 		return (error(NO_MEM, false));
 	*output = new_str;
+	(*index) += 2;
+	return (true);
+}
+
+/*
+**	Handles expanding a $-variable found in the input string:
+**	- If result == 1: expands the environment variable using expand_env_variable.
+**	- If result == 2: expands the exit status using expand_exit_status.
+**	- If result == 0: skips expansion, as the variable does not exist.
+*/
+
+static bool	handle_expansion(t_shell *shell, char **output, char *input,
+								int *index)
+{
+	t_expander	expander[2];
+	int			result;
+
+	if (!input)
+		return (false);
+	expander[0].fn = expand_env_variable;
+	expander[1].fn = expand_exit_status;
+	result = find_or_check_env(shell, input, index, false);
+	if (result == 1 || result == 2)
+		return (expander[result - 1].fn(shell, output, &input[*index + 1],
+				index));
 	return (true);
 }
 
 /*
 **	Helper to check if the dollar sign should trigger variable expansion:
-**	- If the character before the $ is alphanumeric, it's not a variable
-**	- If the character after the $ is not a letter, ?, or _, it's not a variable
-**	- If the character after the $ is a letter, ? or _, check if it's a variable
+**	- Skip expansion inside single quotes.
+**	- Skip expansion if the character before '$' is alphanumeric.
+**	- Expand $? as a special variable for exit status.
+**	- Check if the next character is a valid start for an environment variable.
+**	- Use find_or_check_env to verify if the environment variable exists.
 */
 
-static bool	should_expand_dollar(t_shell *shell, const char *input, int i,
+static bool	should_expand_dollar(t_shell *shell, char *input, int i,
 									bool s_quote)
 {
 	if (!input[i] || input[i] != '$' || s_quote)
 		return (false);
 	if (i > 0 && ft_isalnum(input[i - 1]))
 		return (false);
-	if (input[i + 1] && (ft_isalpha(input[i + 1]) || input[i + 1] == '?'
-			|| input[i + 1] == '_'))
+	if (input[i + 1] == '?')
+		return (true);
+	if (!input[i + 1] || (!ft_isalpha(input[i + 1]) && input[i + 1] != '_'))
 		return (false);
-	if (input[i + 1] != '?' && !env_variable_exists(shell, &input[i + 1]))
+	if (find_or_check_env(shell, &input[i + 1], NULL, true) == 0)
 		return (false);
-	return (true);
-}
-
-/*
-**	Handles expanding a $-variable found in the input string:
-**	- If result == 1 -> expand the environment variable
-**	- If result == 2 -> expand the exit status
-*/
-
-static bool	handle_expansion(t_shell *shell, char **output, char *input,
-								int *index)
-{
-	int	start;
-	int	result;
-
-	start = *index;
-	result = find_env_variable(shell, input, index);
-	if (result == 1)
-		return (expand_env_var(shell, output, &input[start + 1],
-				*index - start - 1));
-	else if (result == 2)
-	{
-		(*index) += 2;
-		return (expand_exit_status(shell, output));
-	}
-	(*index)++;
 	return (true);
 }
 


### PR DESCRIPTION
This pull request includes several changes to the expander functionality in the `minishell` project. The changes focus on refactoring and improving the code related to environment variable expansion. The most important changes include the introduction of a new `t_expander` struct, modifications to the `find_or_check_env` function, and updates to the expander logic in `expander.c`.

### Expander Refactoring and Improvements:

* Introduced a new `t_expander` struct in `inc/minishell.h` to encapsulate expander functions.
* Combined and refactored the `find_env_variable` and `env_variable_exists` functions into a single `find_or_check_env` function in `inc/minishell.h` and `src/helper/expander_utils.c`. [[1]](diffhunk://#diff-71ac2db5fec65368c16ab9fc572b50749d817e528958ff7471446e3ece847671L156-R163) [[2]](diffhunk://#diff-54f948ca3b8deb95103528d93ea376c828a55705f7753ed720bcc00959c05505L9-L98)
* Updated the `expand_env_var` function to `expand_env_variable` and modified its parameters to include `input` and `index` in `src/parsing/expander.c`.
* Refactored the `should_expand_dollar` and `handle_expansion` functions to improve readability and functionality in `src/parsing/expander.c`.

These changes aim to streamline the expander logic and improve the maintainability of the codebase.…ndling of expansion, unify finding and checking env variable in one function, fix match_env_variable