### PR TITLE
feat: add alloc_tracker_remove, update free_allocs and init_alloc_tra…

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/19 19:37:46 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/19 22:50:36 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -125,6 +125,7 @@ typedef struct s_builtin
 
 // --------------  alloc  ------------------------------------------------- //
 void	*alloc_tracker_add(t_alloc *tracker, void *ptr, int is_array);
+void	alloc_tracker_remove(t_alloc *tracker, void *ptr);
 void	free_allocs(t_alloc *tracker);
 
 // --------------  alloc_helper  ------------------------------------------ //
@@ -143,9 +144,9 @@ bool	handle_redirection(t_shell *shell, t_tok *token, t_cmd *cmd);
 t_cmd	*add_cmd(t_shell *shell, t_cmd **lst);
 
 // --------------  env_utils  --------------------------------------------- //
-t_env	*add_env_var(t_shell *shell, t_env **lst, char *data);
+t_env	*add_env_variable(t_shell *shell, t_env **lst, char *data);
 char	*create_prompt(t_shell *shell);
-int		env_var_count(char **env);
+bool	remove_env_variable(t_shell *shell, t_env **lst, char *var_name);
 
 // --------------  error  ------------------------------------------------- //
 bool	error(const char *error_msg, int status);

--- a/src/helper/alloc.c
+++ b/src/helper/alloc.c
@@ -6,32 +6,33 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/15 17:24:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/07 14:05:59 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/19 22:05:02 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
 /*
-**	Dynamically resize the allocation tracker if the capacity is reached.
+**	Dynamically resize the allocation tracker if the capacity is reached,
+**	growing the tracker by 50%.
 */
 
-static bool	alloc_tracker_resize(t_alloc *tracker, int new_capacity)
+static bool	alloc_tracker_resize(t_alloc *tracker)
 {
 	void	**new_allocs;
 	int		*new_flags;
+	int		new_capacity;
 
-	if (!tracker || new_capacity <= tracker->capacity)
+	if (!tracker || tracker->count < tracker->capacity)
 		return (false);
+	new_capacity = tracker->capacity * 1.5;
 	new_allocs = ft_calloc(new_capacity, sizeof(void *));
 	new_flags = ft_calloc(new_capacity, sizeof(int));
 	if (!new_allocs || !new_flags)
 	{
 		free(new_allocs);
 		free(new_flags);
-		new_allocs = NULL;
-		new_flags = NULL;
-		error_exit(NULL, NO_RESIZE, EXIT_FAILURE);
+		error_exit(NULL, NO_MEM, EXIT_FAILURE);
 	}
 	ft_memmove(new_allocs, tracker->allocs, tracker->count * sizeof(void *));
 	ft_memmove(new_flags, tracker->is_array, tracker->count * sizeof(int));
@@ -44,10 +45,8 @@ static bool	alloc_tracker_resize(t_alloc *tracker, int new_capacity)
 }
 
 /*
-**	Alloc tracker, used to keep track of all allocated memory.
-**	Resizes the allocation tracker if initial capacity is reached, 
-**	doubling its capacity.
-**	0 = single allocation, 1 = array allocation
+**	Add a new allocation to the tracker. Resizes if necessary.
+**	0 = single allocation, 1 = array allocation.
 */
 
 void	*alloc_tracker_add(t_alloc *tracker, void *ptr, int is_array)
@@ -56,8 +55,8 @@ void	*alloc_tracker_add(t_alloc *tracker, void *ptr, int is_array)
 		return (NULL);
 	if (tracker->count >= tracker->capacity)
 	{
-		if (!alloc_tracker_resize(tracker, tracker->capacity * 2))
-			return (NULL);
+		if (!alloc_tracker_resize(tracker))
+			return (error(NO_RESIZE, false), NULL);
 	}
 	tracker->allocs[tracker->count] = ptr;
 	tracker->is_array[tracker->count] = is_array;
@@ -66,61 +65,70 @@ void	*alloc_tracker_add(t_alloc *tracker, void *ptr, int is_array)
 }
 
 /*
-**	Free all elements of a char ** array
+**	Remove an element from the allocation tracker efficiently.
+**	Swaps with the last element to improve performance.
 */
 
-static void	free_array(char **array)
+void	alloc_tracker_remove(t_alloc *tracker, void *ptr)
 {
 	int	i;
 
-	if (!array)
+	if (!tracker || !tracker->initialized || !ptr)
 		return ;
 	i = -1;
-	while (array[++i])
+	while (++i < tracker->count)
 	{
-		free(array[i]);
-		array[i] = NULL;
+		if (tracker->allocs[i] == ptr)
+		{
+			tracker->allocs[i] = tracker->allocs[tracker->count - 1];
+			tracker->is_array[i] = tracker->is_array[tracker->count - 1];
+			tracker->allocs[tracker->count - 1] = NULL;
+			tracker->is_array[tracker->count - 1] = 0;
+			tracker->count--;
+			return ;
+		}
 	}
 }
 
 /*
-**	Helper function for free_allocs
+**	Helper function to free memory tracked by the allocation tracker.
+**	If `is_array` is set, frees each element before freeing the main pointer.
 */
 
-static void	free_tracker_allocs(t_alloc *tracker, int index)
+static void	free_tracker_allocs(void *alloc, int is_array)
 {
+	int		i;
 	char	**array;
 
-	if (tracker->is_array[index] == 1)
+	if (!alloc)
+		return ;
+	if (is_array)
 	{
-		array = (char **)tracker->allocs[index];
-		free_array(array);
+		array = (char **)alloc;
+		i = -1;
+		while (array[++i])
+			free(array[i]);
 	}
-	free(tracker->allocs[index]);
-	tracker->allocs[index] = NULL;
+	free(alloc);
 }
 
 /*
-**	Free all allocated memory in one function call
+**	Free all tracked allocations and reset tracker fields.
 */
 
 void	free_allocs(t_alloc *tracker)
 {
-	int		i;
+	int	i;
 
 	if (!tracker || !tracker->allocs || !tracker->initialized)
 		return ;
 	i = -1;
 	while (++i < tracker->count)
 	{
-		if (tracker->allocs[i])
-			free_tracker_allocs(tracker, i);
+		free_tracker_allocs(tracker->allocs[i], tracker->is_array[i]);
+		tracker->allocs[i] = NULL;
 	}
 	free(tracker->allocs);
 	free(tracker->is_array);
-	tracker->allocs = NULL;
-	tracker->is_array = NULL;
-	tracker->count = 0;
-	tracker->capacity = 0;
-	tracker->initialized = false;
+	*tracker = (t_alloc){0};
 }

--- a/src/helper/init.c
+++ b/src/helper/init.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/04 12:12:50 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/13 15:22:34 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/19 22:54:04 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,14 +17,8 @@
 ** the environment size.
 */
 
-static bool	init_alloc_tracker(t_shell *shell, char **env)
+static bool	init_alloc_tracker(t_shell *shell, int initial_capacity)
 {
-	int	initial_capacity;
-
-	if (env)
-		initial_capacity = (env_var_count(env) * 2);
-	else
-		initial_capacity = DEFAULT_ALLOC_CAPACITY;
 	if (!shell || initial_capacity <= 0)
 		return (false);
 	shell->alloc_tracker.allocs = ft_calloc(initial_capacity, sizeof(void *));
@@ -56,7 +50,7 @@ static bool	init_work_dirs(t_shell *shell)
 	tmp = safe_strdup(shell, "OLDPWD");
 	if (!tmp)
 		return (error(NO_MEM, false));
-	if (!add_env_var(shell, &shell->env, tmp))
+	if (!add_env_variable(shell, &shell->env, tmp))
 		return (error(NO_MEM, false));
 	cwd = getcwd(NULL, 0);
 	if (!cwd || !alloc_tracker_add(&shell->alloc_tracker, cwd, 0))
@@ -64,7 +58,7 @@ static bool	init_work_dirs(t_shell *shell)
 	tmp = safe_strjoin(shell, "PWD=", cwd);
 	if (!tmp)
 		return (error(NO_MEM, false));
-	if (!add_env_var(shell, &shell->env, tmp))
+	if (!add_env_variable(shell, &shell->env, tmp))
 		return (error(NO_MEM, false));
 	shell->work_dir = safe_strdup(shell, cwd);
 	if (!shell->work_dir)
@@ -96,7 +90,7 @@ static bool	init_env(t_shell *shell, char **env)
 		tmp = safe_strdup(shell, env[i]);
 		if (!tmp)
 			error_exit(shell, NO_MEM, EXIT_FAILURE);
-		if (!add_env_var(shell, &lst, tmp))
+		if (!add_env_variable(shell, &lst, tmp))
 			return (error(NO_MEM, false));
 	}
 	shell->env = lst;
@@ -129,8 +123,20 @@ static bool	init_prompt(t_shell *shell)
 
 bool	init_shell(t_shell *shell, char **env)
 {
+	int	initial_capacity;
+	int	i;
+
 	ft_memset(shell, 0, sizeof(t_shell));
-	if (!init_alloc_tracker(shell, env))
+	i = 0;
+	if (env)
+	{
+		while (env[i])
+			i++;
+		initial_capacity = (i * 2);
+	}
+	else
+		initial_capacity = DEFAULT_ALLOC_CAPACITY;
+	if (!init_alloc_tracker(shell, initial_capacity))
 		return (error(NO_ALLOC, false));
 	if (!init_work_dirs(shell))
 		return (error(NO_WD, false));


### PR DESCRIPTION
This pull request includes several changes to the `minishell` project, focusing on improving memory allocation tracking, environment variable management, and overall code clarity. The most important changes are listed below:

### Memory Allocation Improvements:
* Added `alloc_tracker_remove` function to remove elements from the allocation tracker efficiently by swapping with the last element. (`inc/minishell.h`, `src/helper/alloc.c`) [[1]](diffhunk://#diff-71ac2db5fec65368c16ab9fc572b50749d817e528958ff7471446e3ece847671R128) [[2]](diffhunk://#diff-2ae869cc63d7e13504b80bd20f9a6001ffac2bf2ca25bdc9149a62ce30463e9aL69-R116)
* Modified `alloc_tracker_resize` to dynamically grow the tracker by 50% instead of requiring a new capacity parameter. (`src/helper/alloc.c`) [[1]](diffhunk://#diff-2ae869cc63d7e13504b80bd20f9a6001ffac2bf2ca25bdc9149a62ce30463e9aL9-R35) [[2]](diffhunk://#diff-2ae869cc63d7e13504b80bd20f9a6001ffac2bf2ca25bdc9149a62ce30463e9aL47-R49)
* Simplified the `free_allocs` function to reset tracker fields using a single assignment. (`src/helper/alloc.c`)

### Environment Variable Management:
* Renamed `add_env_var` to `add_env_variable` for clarity and added `remove_env_variable` function to handle the removal of environment variables. (`inc/minishell.h`, `src/helper/env_utils.c`, `src/helper/init.c`) [[1]](diffhunk://#diff-71ac2db5fec65368c16ab9fc572b50749d817e528958ff7471446e3ece847671L146-R149) [[2]](diffhunk://#diff-d594defa50d347f5768d3f1bc9730e788fa6174a87bf3bcb85d0005e84926b89L35-R47) [[3]](diffhunk://#diff-7d751a8b8b2019ef57359a63f034857ab6dbc98b94cdfb30df859f1fb60237bdL59-R61)
* Improved `create_prompt` function to cache `shell->home_dir` and ensure safe access by checking string lengths. (`src/helper/env_utils.c`)

### General Code Improvements:
* Updated header file comments to reflect recent changes and ensure consistency. (`inc/minishell.h`)
* Modified `init_alloc_tracker` function to accept `initial_capacity` directly instead of calculating it from the environment. (`src/helper/init.c`) [[1]](diffhunk://#diff-7d751a8b8b2019ef57359a63f034857ab6dbc98b94cdfb30df859f1fb60237bdL20-L27) [[2]](diffhunk://#diff-7d751a8b8b2019ef57359a63f034857ab6dbc98b94cdfb30df859f1fb60237bdR126-R139)…cker, add remove_env_variable