### PR TITLE
feat: add alloc_tracker_replace to correctly track and free readline …

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/24 00:16:14 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/24 18:14:43 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,26 +91,26 @@ typedef enum e_error
 
 typedef struct s_env
 {
-	char			    *data;
+	char			*data;
 	struct s_env	*next;
 	struct s_env	*prev;
 }	t_env;
 
 typedef struct s_cmd
 {
-	char	    		*cmd;
-	char			    **args;
-	int				    fd_in;
-	int				    fd_out;
+	char			*cmd;
+	char			**args;
+	int				fd_in;
+	int				fd_out;
 	struct s_cmd	*next;
 	struct s_cmd	*prev;
 }	t_cmd;
 
 typedef struct s_tok
 {
-	char			    *content;
-	char			    *file;
-	t_t_typ			   type;
+	char			*content;
+	char			*file;
+	t_t_typ			type;
 	struct s_tok	*next;
 	struct s_tok	*prev;
 }	t_tok;
@@ -124,12 +124,12 @@ typedef struct s_shell	t_shell;
 
 typedef struct s_alloc_tracker
 {
-	void	  **allocs;
-	int		  *is_array;
-	int		  count;
-	int	    capacity;
-	bool    initialized;
-	t_shell *shell;
+	void	**allocs;
+	int		*is_array;
+	int		count;
+	int		capacity;
+	bool	initialized;
+	t_shell	*shell;
 }	t_alloc;
 
 typedef struct s_shell
@@ -137,7 +137,7 @@ typedef struct s_shell
 	t_cmd			*cmd;			// Command list
 	t_env			*env;			// Environment variables
 	t_tok			*tokens;		// Token list
-	t_alloc		alloc_tracker;	// Memory tracker
+	t_alloc			alloc_tracker;	// Memory tracker
 	int				env_count;		// Environment variable count
 	int				status;			// Exit status
 	char			*prompt;		// Prompt string
@@ -163,6 +163,7 @@ void	alloc_tracker_remove(t_alloc *tracker, void *ptr);
 void	free_allocs(t_alloc *tracker);
 
 // --------------  alloc_helper  ------------------------------------------ //
+void	*alloc_tracker_replace(t_alloc *tracker, void *old_ptr, void *new_ptr);
 void	*safe_malloc(t_shell *shell, size_t size);
 void	*safe_calloc(t_shell *shell, size_t count, size_t size);
 char	*safe_strdup(t_shell *shell, const char *src);

--- a/src/helper/alloc_helper.c
+++ b/src/helper/alloc_helper.c
@@ -6,12 +6,38 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 17:46:41 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/23 10:35:19 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/24 17:56:40 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
+/*
+**	Replace an old pointer with a new one in the allocation tracker.
+**	If the old pointer is NULL, the new pointer is added to the tracker.
+**	This function correctly frees the readline buffer when replacing it.
+*/
+
+void	*alloc_tracker_replace(t_alloc *tracker, void *old_ptr, void *new_ptr)
+{
+	int	i;
+
+	if (!tracker || !new_ptr)
+		return (NULL);
+	if (!old_ptr)
+		return (alloc_tracker_add(tracker, new_ptr, 0));
+	i = -1;
+	while (++i < tracker->count)
+	{
+		if (tracker->allocs[i] == old_ptr)
+		{
+			free(tracker->allocs[i]);
+			tracker->allocs[i] = new_ptr;
+			return (new_ptr);
+		}
+	}
+	return (NULL);
+}
 /*
 **	Wrapper for strdup, automatically adding the allocation to the tracker
 */

--- a/src/helper/clean.c
+++ b/src/helper/clean.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/22 14:10:12 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/23 10:35:49 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/24 18:11:34 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,17 +20,26 @@
 
 void	cleanup_fds(t_cmd *cmd)
 {
+	t_cmd	*current;
+
 	if (!cmd)
 		return ;
-	if (cmd->fd_in > 2)
+	current = cmd;
+	while (current)
 	{
-		close(cmd->fd_in);
-		cmd->fd_in = -2;
-	}
-	if (cmd->fd_out > 2)
-	{
-		close(cmd->fd_out);
-		cmd->fd_out = -2;
+		if (current->fd_in > 2)
+		{
+			close(current->fd_in);
+			current->fd_in = -2;
+		}
+		if (current->fd_out > 2)
+		{
+			close(current->fd_out);
+			current->fd_out = -2;
+		}
+		current = current->next;
+		if (current == cmd)
+			break ;
 	}
 }
 
@@ -43,5 +52,6 @@ void	clean_shell(t_shell *shell)
 {
 	if (!shell)
 		return ;
+	cleanup_fds(shell->cmd);
 	free_allocs(&shell->alloc_tracker);
 }

--- a/src/helper/signal.c
+++ b/src/helper/signal.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 10:47:06 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/23 23:57:32 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/24 18:01:31 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,7 +58,8 @@ void	handle_sigquit(int sig)
 	if (sig == SIGQUIT)
 	{
 		ioctl(STDIN_FILENO, TIOCSTI, &cr);
-		write(1, "Quit (core dumped)", 18);
+		write(2, "Quit (core dumped)", 18);
+		exit (131);
 	}
 }
 
@@ -76,9 +77,6 @@ void	setup_signals(void (*sigint_handler)(int), void (*sigquit_handler)(int))
 	sa.sa_flags = 0;
 	sa.sa_handler = sigint_handler;
 	sigaction(SIGINT, &sa, NULL);
-	if (sigquit_handler == SIG_IGN)
-		sa.sa_handler = SIG_IGN;
-	else
-		sa.sa_handler = sigquit_handler;
+	sa.sa_handler = sigquit_handler;
 	sigaction(SIGQUIT, &sa, NULL);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:48:13 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/24 00:03:01 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/24 17:59:39 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,8 +37,8 @@ static void	minishell(t_shell *shell)
 	while (1)
 	{
 		g_signal = 0;
-		shell->cmd_input = readline(shell->prompt);
-		alloc_tracker_add(&shell->alloc_tracker, shell->cmd_input, 0);
+		shell->cmd_input = alloc_tracker_replace(&shell->alloc_tracker,
+				shell->cmd_input, readline(shell->prompt));
 		if (!shell->cmd_input)
 			break ;
 		if (blank_line(shell->cmd_input))
@@ -47,8 +47,10 @@ static void	minishell(t_shell *shell)
 		if (!tokenize_input(shell, shell->cmd_input))
 			continue ;
 		if (shell->cmd != NULL)
+		{
 			execute(shell);
-		shell->cmd_input = NULL;
+			cleanup_fds(shell->cmd);
+		}
 	}
 	rl_clear_history();
 }
@@ -61,7 +63,10 @@ int	main(int ac, char **av, char **env)
 	if (ac > 1)
 		return (error(INV_ARGS, 1));
 	if (!init_shell(&shell, env))
+	{
+		clean_shell(&shell);
 		return (error(NO_SHELL, 1));
+	}
 	minishell(&shell);
 	clean_shell(&shell);
 	return (0);

--- a/src/parsing/cmd_redir.c
+++ b/src/parsing/cmd_redir.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/06 23:19:30 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/23 17:02:53 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/24 18:13:08 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -90,30 +90,9 @@ static bool	process_redirection(t_shell *shell, t_cmd *cmd, t_tok *token)
 }
 
 /*
-**	Process a redirection and track failure
-**	This function acts as a wrapper around 'process_redirection':
-**	- If 'process_redirection' fails, 'redir_fail' is set to 'true',
-**	  and 'cleanup_fds(cmd)' is called to close any open file descriptors.
-*/
-
-static bool	check_redirection(t_shell *shell, t_cmd *cmd, t_tok *token,
-								bool *redir_fail)
-{
-	if (!process_redirection(shell, cmd, token))
-	{
-		*redir_fail = true;
-		cleanup_fds(cmd);
-		return (false);
-	}
-	return (true);
-}
-
-/*
 **	Process and apply redirections for a command.
 **	- If a redirection fails, the function immediately returns 'false'
 **	  to indicate the command should be skipped.
-**	- After processing all redirections, 'cleanup_fds(cmd)' ensures
-**	  unnecessary file descriptors are closed.
 */
 
 bool	handle_redirection(t_shell *shell, t_tok *token, t_cmd *cmd)
@@ -133,11 +112,10 @@ bool	handle_redirection(t_shell *shell, t_tok *token, t_cmd *cmd)
 	{
 		if (current->type == REDIR_IN || current->type == HEREDOC
 			|| current->type == REDIR_OUT || current->type == REDIR_APPEND)
-			if (!check_redirection(shell, cmd, current, &redir_fail))
-				return (false);
+			if (!process_redirection(shell, cmd, current))
+				return (redir_fail = true, false);
 		current = current->next;
 	}
-	cleanup_fds(cmd);
 	if (redir_fail)
 		return (false);
 	return (true);

--- a/src/parsing/heredoc.c
+++ b/src/parsing/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/13 16:06:25 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/24 00:12:15 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/24 18:19:47 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,13 +36,14 @@ static bool	heredoc_read_input(t_shell *shell, const char *delimiter, int fd)
 	char	*line;
 	int		line_count;
 
+	line = NULL;
 	g_signal = 0;
 	line_count = 0;
 	setup_signals(handle_heredoc_sigint, SIG_IGN);
 	while (!g_signal)
 	{
-		line = readline("> ");
-		alloc_tracker_add(&shell->alloc_tracker, line, 0);
+		line = alloc_tracker_replace(&shell->alloc_tracker, line,
+				readline("> "));
 		line_count++;
 		if (!line)
 		{


### PR DESCRIPTION
This pull request includes several changes to improve memory management, signal handling, and file descriptor cleanup in the `minishell` project. The most important changes include adding a new function for replacing pointers in the allocation tracker, refining the cleanup process for file descriptors, and updating signal handling to ensure proper termination.

Memory management improvements:

* [`inc/minishell.h`](diffhunk://#diff-71ac2db5fec65368c16ab9fc572b50749d817e528958ff7471446e3ece847671R166): Added the declaration for `alloc_tracker_replace` function to replace an old pointer with a new one in the allocation tracker.
* [`src/helper/alloc_helper.c`](diffhunk://#diff-2d2b3373b5321eccac83f8e610cb258301141c9bd5d8f2492760e77e5786c0d9L9-R40): Implemented the `alloc_tracker_replace` function to handle pointer replacement and memory management.

File descriptor cleanup:

* [`src/helper/clean.c`](diffhunk://#diff-b7e965b544227f1ec020bb5df3f45066dc02c5ebd743326091340ce1aa87be78R23-R42): Enhanced `cleanup_fds` to iterate through command structures and close file descriptors properly. Also, integrated `cleanup_fds` into the `clean_shell` function. [[1]](diffhunk://#diff-b7e965b544227f1ec020bb5df3f45066dc02c5ebd743326091340ce1aa87be78R23-R42) [[2]](diffhunk://#diff-b7e965b544227f1ec020bb5df3f45066dc02c5ebd743326091340ce1aa87be78R55)
* [`src/main.c`](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L40-R41): Updated the `minishell` function to use `alloc_tracker_replace` for managing command input and added `cleanup_fds` calls to ensure file descriptors are closed after command execution. [[1]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L40-R41) [[2]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176R50-R53) [[3]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176R66-R69)

Signal handling updates:

* [`src/helper/signal.c`](diffhunk://#diff-62bc3765a39df3f071f1a7a7c024e8e8f73b1b96c50f75bbb7eddbb28c9407e1L61-R62): Modified `handle_sigquit` to write to standard error and exit with a status code. Simplified `setup_signals` by removing unnecessary condition checks. [[1]](diffhunk://#diff-62bc3765a39df3f071f1a7a7c024e8e8f73b1b96c50f75bbb7eddbb28c9407e1L61-R62) [[2]](diffhunk://#diff-62bc3765a39df3f071f1a7a7c024e8e8f73b1b96c50f75bbb7eddbb28c9407e1L79-L81)

Parsing and redirection adjustments:

* [`src/parsing/cmd_redir.c`](diffhunk://#diff-7b015f699cd1a3e2f7b8d9f203d474edda941a2da9f7f414dea25f827e2cce34L92-L116): Removed the redundant `check_redirection` function and streamlined the `handle_redirection` function to directly call `process_redirection`. [[1]](diffhunk://#diff-7b015f699cd1a3e2f7b8d9f203d474edda941a2da9f7f414dea25f827e2cce34L92-L116) [[2]](diffhunk://#diff-7b015f699cd1a3e2f7b8d9f203d474edda941a2da9f7f414dea25f827e2cce34L136-L140)
* [`src/parsing/heredoc.c`](diffhunk://#diff-395cdac3f4535bade1246685f119ffd44c65bd68b5686f9baaed67b7b207a4fdR39-R46): Updated `heredoc_read_input` to use `alloc_tracker_replace` for managing readline input.…buffer, update cleanup_fds so now it corre

ctly closes all open fds