### PR TITLE
fix: fix expansion in heredoc and its delimiter

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/27 14:18:57 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/02/27 19:02:56 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -122,6 +122,7 @@ typedef struct s_tok
 	char						*content;
 	char						*file;
 	t_t_typ						type;
+	bool						is_quoted;
 	struct s_tok				*next;
 	struct s_tok				*prev;
 }								t_tok;
@@ -262,7 +263,7 @@ bool							tokenize_input(t_shell *shell, char *input);
 // --------------  token_utils  ------------------------------------------- //
 t_t_typ							identify_special_token(char *str);
 int								get_special_length(char *str);
-int								get_token_length(char *input, int *quote);
+int								get_token_length(char *input);
 t_tok							*add_token(t_shell *shell, t_tok **lst,
 									char *content, t_t_typ type);
 

--- a/src/helper/error.c
+++ b/src/helper/error.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/26 18:09:55 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/27 14:18:48 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/02/28 01:06:46 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,7 +49,7 @@ void	error_exit(t_shell *shell, t_error err, char *context, int status)
 		ft_putstr_fd(context, 2);
 		ft_putstr_fd(": ", 2);
 	}
-	ft_putendl_fd((char *)g_error_msgs[err], 2);
+	ft_putstr_fd((char *)g_error_msgs[err], 2);
 	ft_putstr_fd(": ", 2);
 	ft_putendl_fd(strerror(errno), 2);
 	if (shell)

--- a/src/helper/token_utils.c
+++ b/src/helper/token_utils.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/09 15:46:52 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/23 09:29:35 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/27 19:02:56 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,18 +49,16 @@ int	get_special_length(char *str)
 **	Get length of a token while handling quotes
 */
 
-int	get_token_length(char *input, int *quote)
+int	get_token_length(char *input)
 {
 	int		len;
 
 	len = 0;
-	*quote = 0;
 	while (input[len] && !get_special_length(input + len)
 		&& !ft_isblank(input[len]))
 	{
 		if (input[len] == '\'' || input[len] == '"')
 		{
-			(*quote)++;
 			if (input[len++] == '"')
 				while (input[len] && input[len] != '"')
 					len++;
@@ -90,6 +88,7 @@ static	t_tok	*init_token(t_shell *shell, char *content, t_t_typ type)
 	token->content = content;
 	token->file = NULL;
 	token->type = type;
+	token->is_quoted = false;
 	token->next = NULL;
 	token->prev = NULL;
 	return (token);

--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 20:37:00 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/27 23:49:09 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/28 00:56:05 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -110,13 +110,14 @@ static bool	should_expand_dollar(t_shell *shell, char *input, int i, bool s_quot
 	j = i - 1;
 	while (j > 0 && (ft_isblank(input[j]) || input[j] == '"' || input[j] == '\''))
 		j--;
-	if (j > 1 && input[j] == '<' && input[j - 1] == '<')
+	if ((j == 1 && input[j] == '<' && input[j - 1] == '<')
+			|| (j > 1 && input[j] == '<' && input[j - 1] == '<'))
 	{
 		k = j + 2;
 		while (input[k] && ft_isblank(input[k]))
 			k++;
-		if (input[k] == '"' || input[k] == '\'' || input[k] == '$')
-				return (false);
+		if (input[k] != '\0')
+			return (false);
 	}
 	if (input[i + 1] == '?')
 		return (true);

--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 20:37:00 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/23 09:42:12 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/27 19:13:23 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -89,6 +89,7 @@ static bool	handle_expansion(t_shell *shell, char **output, char *input,
 **	Helper to check if the dollar sign should trigger variable expansion:
 **	- Skip expansion inside single quotes.
 **	- Skip expansion if the character before '$' is alphanumeric.
+**	- Skip expansion after '<<' (heredoc).
 **	- Expand $? as a special variable for exit status.
 **	- Check if the next character is a valid start for an environment variable.
 **	- Use find_or_check_env to verify if the environment variable exists.
@@ -97,9 +98,16 @@ static bool	handle_expansion(t_shell *shell, char **output, char *input,
 static bool	should_expand_dollar(t_shell *shell, char *input, int i,
 									bool s_quote)
 {
+	int	j;
+
 	if (!input[i] || input[i] != '$' || s_quote)
 		return (false);
 	if (i > 0 && ft_isalnum(input[i - 1]))
+		return (false);
+	j = i - 1;
+	while (j > 0 && ft_isblank(input[j]))
+		j--;
+	if (j > 0 && input[j - 1] == '<' && input[j] == '<')
 		return (false);
 	if (input[i + 1] == '?')
 		return (true);

--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 20:37:00 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/27 19:13:23 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/27 23:49:09 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -87,28 +87,37 @@ static bool	handle_expansion(t_shell *shell, char **output, char *input,
 
 /*
 **	Helper to check if the dollar sign should trigger variable expansion:
-**	- Skip expansion inside single quotes.
-**	- Skip expansion if the character before '$' is alphanumeric.
-**	- Skip expansion after '<<' (heredoc).
-**	- Expand $? as a special variable for exit status.
-**	- Check if the next character is a valid start for an environment variable.
-**	- Use find_or_check_env to verify if the environment variable exists.
+**	The function performs the following checks:
+** 	- Returns false if '$' is preceded by an alphanumeric character (e.g., 'VAR$USER').
+** 	- Returns false if '$' appears inside single quotes ('''), as they prevent expansion.
+** 	- Detects if '$' is used within a heredoc ('<<') and determines if expansion should occur:
+** 	  - If the heredoc delimiter is quoted ('<< "$VAR"'), expansion is prevented.
+** 	  - If the heredoc delimiter is unquoted ('<< VAR'), expansion is allowed.
+** 	- Returns true for '$?', as it should always be expanded.
+** 	- Ensures only valid variable names are expanded ('$VAR' but not '$1VAR').
+** 	- Returns false if the environment variable does not exist.
 */
 
-static bool	should_expand_dollar(t_shell *shell, char *input, int i,
-									bool s_quote)
+static bool	should_expand_dollar(t_shell *shell, char *input, int i, bool s_quote)
 {
 	int	j;
+	int	k;
 
 	if (!input[i] || input[i] != '$' || s_quote)
 		return (false);
 	if (i > 0 && ft_isalnum(input[i - 1]))
 		return (false);
 	j = i - 1;
-	while (j > 0 && ft_isblank(input[j]))
+	while (j > 0 && (ft_isblank(input[j]) || input[j] == '"' || input[j] == '\''))
 		j--;
-	if (j > 0 && input[j - 1] == '<' && input[j] == '<')
-		return (false);
+	if (j > 1 && input[j] == '<' && input[j - 1] == '<')
+	{
+		k = j + 2;
+		while (input[k] && ft_isblank(input[k]))
+			k++;
+		if (input[k] == '"' || input[k] == '\'' || input[k] == '$')
+				return (false);
+	}
 	if (input[i + 1] == '?')
 		return (true);
 	if (!input[i + 1] || (!ft_isalpha(input[i + 1]) && input[i + 1] != '_'))

--- a/src/parsing/heredoc.c
+++ b/src/parsing/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/13 16:06:25 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/24 18:19:47 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/27 18:55:52 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,7 +52,7 @@ static bool	heredoc_read_input(t_shell *shell, const char *delimiter, int fd)
 		}
 		if (ft_strcmp(line, delimiter) == 0)
 			break ;
-		if (!expand_dollar_variables(shell, &line))
+		if (!shell->tokens->is_quoted && !expand_dollar_variables(shell, &line))
 			error_exit(shell, NO_EXPAND, "heredoc_read_input", EXIT_FAILURE);
 		ft_putendl_fd(line, fd);
 	}

--- a/src/parsing/token.c
+++ b/src/parsing/token.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 12:41:04 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/23 10:39:57 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/27 19:10:38 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,16 +26,26 @@ static bool	parse_word_token(t_shell *shell, t_tok **lst, char **input)
 {
 	t_t_typ	token_type;
 	char	*content;
-	int		quote_count;
+	bool	is_quoted;
 	int		len;
+	int		i;
 
-	len = get_token_length(*input, &quote_count);
-	if ((len - (2 * quote_count)) < 0)
+	len = get_token_length(*input);
+	if (len == 0)
 		return (true);
+	is_quoted = false;
+	i = -1;
+	while (++i < len)
+	{
+		if ((*input)[i] == '\'' || (*input)[i] == '"')
+			is_quoted = true;
+	}
 	content = trim_quotes(shell, *input, len);
 	token_type = determine_token_type(lst);
 	if (!add_token(shell, lst, content, token_type))
 		return (false);
+	if (token_type == ARG)
+		(*lst)->is_quoted = is_quoted;
 	*input += len;
 	return (true);
 }


### PR DESCRIPTION
This pull request includes several changes to the `minishell` project, focusing on handling quoted tokens, updating token length calculations, and improving variable expansion logic. The most important changes include adding a new field to the token structure, updating token length functions, and refining the handling of dollar sign expansions.

### Token structure and handling:

* Added a new `is_quoted` field to the `t_tok` structure to track whether a token is quoted. (`inc/minishell.h`, [inc/minishell.hR125](diffhunk://#diff-71ac2db5fec65368c16ab9fc572b50749d817e528958ff7471446e3ece847671R125))
* Updated the `init_token` function to initialize the `is_quoted` field to `false`. (`src/helper/token_utils.c`, [src/helper/token_utils.cR91](diffhunk://#diff-14b70ba9110826ab0ebb112d35abcf25541ffe181c84235b6ca4affbb6231d28R91))

### Token length calculations:

* Removed the `quote` parameter from the `get_token_length` function and adjusted its logic accordingly. (`inc/minishell.h`, [[1]](diffhunk://#diff-71ac2db5fec65368c16ab9fc572b50749d817e528958ff7471446e3ece847671L265-R266); `src/helper/token_utils.c`, [[2]](diffhunk://#diff-14b70ba9110826ab0ebb112d35abcf25541ffe181c84235b6ca4affbb6231d28L52-L63)

### Variable expansion:

* Enhanced the `should_expand_dollar` function to skip expansion after a heredoc delimiter (`<<`). (`src/parsing/expander.c`, [src/parsing/expander.cR101-R111](diffhunk://#diff-b13287957eb8cb7eb2d1c85a681d1ba9658bb81875e0665c94818acf40be73b5R101-R111))
* Modified the `heredoc_read_input` function to check the `is_quoted` field before expanding dollar variables. (`src/parsing/heredoc.c`, [src/parsing/heredoc.cL55-R55](diffhunk://#diff-395cdac3f4535bade1246685f119ffd44c65bd68b5686f9baaed67b7b207a4fdL55-R55))

These changes collectively improve the handling of quoted tokens and variable expansions in the `minishell` project.