### PR TITLE
Temporary fix first cmd issue

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/27 14:18:57 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/02/27 19:02:56 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -122,6 +122,7 @@ typedef struct s_tok
 	char						*content;
 	char						*file;
 	t_t_typ						type;
+	bool						is_quoted;
 	struct s_tok				*next;
 	struct s_tok				*prev;
 }								t_tok;
@@ -262,7 +263,7 @@ bool							tokenize_input(t_shell *shell, char *input);
 // --------------  token_utils  ------------------------------------------- //
 t_t_typ							identify_special_token(char *str);
 int								get_special_length(char *str);
-int								get_token_length(char *input, int *quote);
+int								get_token_length(char *input);
 t_tok							*add_token(t_shell *shell, t_tok **lst,
 									char *content, t_t_typ type);
 

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/27 19:02:56 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/27 19:57:35 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -206,7 +206,7 @@ t_cmd							*add_cmd(t_shell *shell, t_cmd **lst);
 void							skip_invalid_command(t_shell *shell,
 									t_tok **current);
 bool							is_command_start(t_tok *current);
-t_t_typ							determine_token_type(t_tok **lst);
+t_t_typ							determine_token_type(t_tok **lst, bool foo);
 
 // --------------  env_utils  --------------------------------------------- //
 t_env							*add_env_variable(t_shell *shell, t_env **lst,

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:54:56 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/27 14:14:34 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/02/27 19:30:55 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,7 +46,7 @@ void	builtin_exit(t_shell *shell, t_cmd *cmd)
 		error_exit(shell, EXIT_INVALID_ARGUMENT, "exit", 2);
 	}
 	if (count > 1)
-		shell->status = ft_atoi(cmd->args[1]); // TODO: protect
+		shell->status = ft_atoi(cmd->args[1]);
 	if (count > 2)
 	{
 		shell->status = 1;

--- a/src/helper/cmd_utils.c
+++ b/src/helper/cmd_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   cmd_utils.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
+/*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/03 12:01:30 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/26 01:46:46 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/27 19:59:56by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,7 +64,7 @@ t_cmd	*add_cmd(t_shell *shell, t_cmd **lst)
 /*
 **	Skip an invalid command after redirection failure
 **	- If a command has a redirection failure, this function moves 'current'
-**	  forward until it reaches a pipe or the end.
+**		forward until it reaches a pipe or the end.
 **	- If we reach a  pipe, it ensures the next command is processed.
 */
 
@@ -86,7 +86,7 @@ void	skip_invalid_command(t_shell *shell, t_tok **current)
 **	Check if the current token is the start of a new command
 **	- A command starts if the token is of type CMD.
 **	- An ARG token may also be the start of a command if:
-**		- It follows a PIPE, or 
+**		- It follows a PIPE, or
 **		- It follows a redirection which is preceded by a PIPE.
 */
 
@@ -115,7 +115,7 @@ bool	is_command_start(t_tok *current)
 **	- If it follows an 'ARG' that itself follows a redirection, it is a 'CMD'.
 */
 
-t_t_typ	determine_token_type(t_tok **lst)
+t_t_typ	determine_token_type(t_tok **lst, bool first_cmd_found)
 {
 	t_tok	*prev_token;
 
@@ -127,7 +127,7 @@ t_t_typ	determine_token_type(t_tok **lst)
 	else if (prev_token->type == REDIR_IN || prev_token->type == REDIR_OUT
 		|| prev_token->type == HEREDOC || prev_token->type == REDIR_APPEND)
 		return (ARG);
-	else if (prev_token->type == ARG && prev_token->prev
+	else if (!first_cmd_found&& prev_token->type == ARG && prev_token->prev
 		&& (prev_token->prev->type == REDIR_IN
 			|| prev_token->prev->type == REDIR_OUT
 			|| prev_token->prev->type == HEREDOC

--- a/src/helper/token_utils.c
+++ b/src/helper/token_utils.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/09 15:46:52 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/23 09:29:35 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/27 19:02:56 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,18 +49,16 @@ int	get_special_length(char *str)
 **	Get length of a token while handling quotes
 */
 
-int	get_token_length(char *input, int *quote)
+int	get_token_length(char *input)
 {
 	int		len;
 
 	len = 0;
-	*quote = 0;
 	while (input[len] && !get_special_length(input + len)
 		&& !ft_isblank(input[len]))
 	{
 		if (input[len] == '\'' || input[len] == '"')
 		{
-			(*quote)++;
 			if (input[len++] == '"')
 				while (input[len] && input[len] != '"')
 					len++;
@@ -90,6 +88,7 @@ static	t_tok	*init_token(t_shell *shell, char *content, t_t_typ type)
 	token->content = content;
 	token->file = NULL;
 	token->type = type;
+	token->is_quoted = false;
 	token->next = NULL;
 	token->prev = NULL;
 	return (token);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:48:13 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/27 13:14:30 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/02/27 19:42:54 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,6 +65,24 @@ static void	print_env_data(t_env *env)
 	}
 }
 
+static void	print_tokens(t_tok *tokens)
+{
+	t_tok	*current_token;
+	int		i;
+
+	i = 0;
+	current_token = tokens;
+	while (current_token)
+	{
+		printf("Token %d (%d): %s\n", i, current_token->type,
+			current_token->content);
+		current_token = current_token->next;
+		if (current_token == tokens)
+			break ;
+		i++;
+	}
+}
+
 void	print_parsed_data(t_shell *shell)
 {
 	size_t	cmd_count;
@@ -73,6 +91,7 @@ void	print_parsed_data(t_shell *shell)
 
 	printf("Printing shell data...\n");
 	print_env_data(shell->env);
+	print_tokens(shell->tokens);
 	printf("Status: %d\n", shell->status);
 	printf("Prompt: %s\n", shell->prompt);
 	printf("Cmd_input: %s\n", shell->cmd_input);

--- a/src/parsing/cmd_redir.c
+++ b/src/parsing/cmd_redir.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   cmd_redir.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
+/*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/06 23:19:30 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/26 01:44:57 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/27 20:01:08 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,8 +31,9 @@ bool	invalid_redirection(t_tok *token)
 	{
 		if (!current->next)
 			return (true);
-		if ((current->type == REDIR_IN || current->type == REDIR_OUT
-				|| current->type == HEREDOC || current->type == REDIR_APPEND
+		if ((current->type == REDIR_IN
+				|| current->type == REDIR_OUT
+				|| current->type == HEREDOC
 				|| current->type == REDIR_APPEND)
 			&& (current->next->type != ARG))
 			return (true);

--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 20:37:00 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/23 09:42:12 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/27 19:13:23 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -89,6 +89,7 @@ static bool	handle_expansion(t_shell *shell, char **output, char *input,
 **	Helper to check if the dollar sign should trigger variable expansion:
 **	- Skip expansion inside single quotes.
 **	- Skip expansion if the character before '$' is alphanumeric.
+**	- Skip expansion after '<<' (heredoc).
 **	- Expand $? as a special variable for exit status.
 **	- Check if the next character is a valid start for an environment variable.
 **	- Use find_or_check_env to verify if the environment variable exists.
@@ -97,9 +98,16 @@ static bool	handle_expansion(t_shell *shell, char **output, char *input,
 static bool	should_expand_dollar(t_shell *shell, char *input, int i,
 									bool s_quote)
 {
+	int	j;
+
 	if (!input[i] || input[i] != '$' || s_quote)
 		return (false);
 	if (i > 0 && ft_isalnum(input[i - 1]))
+		return (false);
+	j = i - 1;
+	while (j > 0 && ft_isblank(input[j]))
+		j--;
+	if (j > 0 && input[j - 1] == '<' && input[j] == '<')
 		return (false);
 	if (input[i + 1] == '?')
 		return (true);

--- a/src/parsing/heredoc.c
+++ b/src/parsing/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/13 16:06:25 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/24 18:19:47 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/27 18:55:52 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,7 +52,7 @@ static bool	heredoc_read_input(t_shell *shell, const char *delimiter, int fd)
 		}
 		if (ft_strcmp(line, delimiter) == 0)
 			break ;
-		if (!expand_dollar_variables(shell, &line))
+		if (!shell->tokens->is_quoted && !expand_dollar_variables(shell, &line))
 			error_exit(shell, NO_EXPAND, "heredoc_read_input", EXIT_FAILURE);
 		ft_putendl_fd(line, fd);
 	}

--- a/src/parsing/token.c
+++ b/src/parsing/token.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 12:41:04 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/23 10:39:57 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/02/27 19:10:38 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,16 +26,26 @@ static bool	parse_word_token(t_shell *shell, t_tok **lst, char **input)
 {
 	t_t_typ	token_type;
 	char	*content;
-	int		quote_count;
+	bool	is_quoted;
 	int		len;
+	int		i;
 
-	len = get_token_length(*input, &quote_count);
-	if ((len - (2 * quote_count)) < 0)
+	len = get_token_length(*input);
+	if (len == 0)
 		return (true);
+	is_quoted = false;
+	i = -1;
+	while (++i < len)
+	{
+		if ((*input)[i] == '\'' || (*input)[i] == '"')
+			is_quoted = true;
+	}
 	content = trim_quotes(shell, *input, len);
 	token_type = determine_token_type(lst);
 	if (!add_token(shell, lst, content, token_type))
 		return (false);
+	if (token_type == ARG)
+		(*lst)->is_quoted = is_quoted;
 	*input += len;
 	return (true);
 }


### PR DESCRIPTION
This PR showcases how the issue about CMD classification may be addressed. It should never be merged.

Example case: `echo < infile foobar` -> without this fix, 'foobar' overwrites 'echo' as the CMD, causing the shell to attempt to execute foobar.