### PR TITLE
fix(exit): don't print 'exit' in subshells

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/27 14:18:57 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/02/27 20:55:43 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -148,6 +148,7 @@ typedef struct s_shell
 	t_env *env;            // Environment variables
 	t_tok *tokens;         // Token list
 	t_alloc alloc_tracker; // Memory tracker
+	size_t cmd_count;      // Number of distinct commands (subshells)
 	int env_count;         // Environment variable count
 	int status;            // Exit status
 	char *prompt;          // Prompt string
@@ -267,22 +268,19 @@ t_tok							*add_token(t_shell *shell, t_tok **lst,
 									char *content, t_t_typ type);
 
 // --------------  command runner  ---------------------------------------- //
-void							dispatch(t_shell *shell, size_t cmd_count);
+void							dispatch(t_shell *shell);
 void							execute_single_builtin(t_shell *shell,
 									t_b_typ type);
 void							execute_with_pipeline(t_shell *shell,
-									t_cmd *command, size_t cmd_count,
-									int *pipe_fd);
+									t_cmd *command, int *pipe_fd);
 void							execute_builtin(t_shell *shell, t_cmd *cmd,
 									t_b_typ type);
 void							execute_command(t_shell *shell, t_cmd *command);
 int								wait_for_children(t_shell *shell,
-									t_cmd *command, size_t cmd_count);
+									t_cmd *command);
 
-void							prepare_execution(t_shell *shell,
-									size_t cmd_count);
-void							postpare_execution(t_shell *shell,
-									size_t cmd_count);
+void							prepare_execution(t_shell *shell);
+void							postpare_execution(t_shell *shell);
 char							**get_env_array(t_shell *shell);
 
 bool							is_path(char *str);

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:54:56 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/27 14:14:34 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/02/27 20:38:54 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,8 @@ void	builtin_exit(t_shell *shell, t_cmd *cmd)
 {
 	size_t	count;
 
-	printf("exit\n");
+	if (shell->cmd_count == 1)
+		printf("exit\n");
 	count = count_cmd_args(cmd);
 	if (count == 1)
 	{

--- a/src/execution/execute.c
+++ b/src/execution/execute.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 17:26:32 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/27 13:15:28 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/02/27 20:56:24 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,21 +61,20 @@ static void	execute_without_pipeline(t_shell *shell)
 	{
 		execute_command(shell, shell->cmd);
 	}
-	shell->status = wait_for_children(shell, shell->cmd, 1);
+	shell->status = wait_for_children(shell, shell->cmd);
 }
 
 // entrypoint for any execution
-void	dispatch(t_shell *shell, size_t cmd_count)
+void	dispatch(t_shell *shell)
 {
 	int		pipe_fd[2];
 	t_b_typ	type;
 
-	print_parsed_data(shell);
-	if (cmd_count != 1)
+	if (shell->cmd_count != 1)
 	{
 		pipe_fd[0] = -2;
 		pipe_fd[1] = -2;
-		execute_with_pipeline(shell, shell->cmd, cmd_count, pipe_fd);
+		execute_with_pipeline(shell, shell->cmd, pipe_fd);
 		return ;
 	}
 	if (!shell->cmd->args)

--- a/src/execution/setup.c
+++ b/src/execution/setup.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 19:55:42 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/27 13:23:09 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/02/27 20:55:00 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,14 +41,14 @@ static void	find_absolute_path(t_shell *shell, t_cmd *cmd)
 	cmd->cmd = safe_strdup(shell, "");
 }
 
-static void	get_absolute_paths(t_shell *shell, size_t cmd_count)
+static void	get_absolute_paths(t_shell *shell)
 {
 	size_t	i;
 	t_cmd	*current_command;
 
 	i = 0;
 	current_command = shell->cmd;
-	while (i < cmd_count)
+	while (i < shell->cmd_count)
 	{
 		find_absolute_path(shell, current_command);
 		current_command = current_command->next;
@@ -79,14 +79,32 @@ static void	set_env_as_array(t_shell *shell)
 		error_exit(shell, NO_ALLOC, "get_env_array", EXIT_FAILURE);
 }
 
+static void	set_cmd_count(t_shell *shell)
+{
+	t_cmd	*current_cmd;
+	size_t	count;
+
+	count = 0;
+	current_cmd = shell->cmd;
+	while (current_cmd)
+	{
+		count++;
+		current_cmd = current_cmd->next;
+		if (current_cmd == shell->cmd)
+			break ;
+	}
+	shell->cmd_count = count;
+}
+
 // minimize allocations in the execution flow for easier error handling
 // by front-loading anything we can before going too deep into exec
 // if no PATH set, return and use cwd instead
 // if anything goes wrong, most likely just a malloc fail,
 // error_exit() is called.
-void	prepare_execution(t_shell *shell, size_t cmd_count)
+void	prepare_execution(t_shell *shell)
 {
+	set_cmd_count(shell);
 	set_path_segments(shell);
-	get_absolute_paths(shell, cmd_count);
+	get_absolute_paths(shell);
 	set_env_as_array(shell);
 }

--- a/src/execution/teardown.c
+++ b/src/execution/teardown.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 19:55:34 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/25 22:11:02 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/02/27 20:48:36 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,14 +47,14 @@ static void	clean_env_array(t_shell *shell)
 	}
 }
 
-static void	clean_absolute_paths(t_shell *shell, size_t cmd_count)
+static void	clean_absolute_paths(t_shell *shell)
 {
 	size_t	i;
 	t_cmd	*current_command;
 
 	i = 0;
 	current_command = shell->cmd;
-	while (i < cmd_count)
+	while (i < shell->cmd_count)
 	{
 		alloc_tracker_remove(&shell->alloc_tracker, current_command->cmd);
 		free(current_command->cmd);
@@ -64,10 +64,10 @@ static void	clean_absolute_paths(t_shell *shell, size_t cmd_count)
 	}
 }
 
-void	postpare_execution(t_shell *shell, size_t cmd_count)
+void	postpare_execution(t_shell *shell)
 {
 	clean_path_segments(shell);
 	clean_env_array(shell);
-	clean_absolute_paths(shell, cmd_count);
+	clean_absolute_paths(shell);
 	cleanup_fds(shell->cmd);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:48:13 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/27 13:14:30 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/02/27 20:56:10 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,7 +67,6 @@ static void	print_env_data(t_env *env)
 
 void	print_parsed_data(t_shell *shell)
 {
-	size_t	cmd_count;
 	t_cmd	*current_command;
 	size_t	i;
 
@@ -81,17 +80,9 @@ void	print_parsed_data(t_shell *shell)
 	printf("Old_work_dir: %s\n", shell->old_work_dir);
 	printf("User: %s\n", shell->user);
 	current_command = shell->cmd;
-	cmd_count = 0;
-	while (current_command)
-	{
-		cmd_count++;
-		current_command = current_command->next;
-		if (current_command == shell->cmd)
-			break ;
-	}
-	printf("Commands (%lu):\n\n", cmd_count);
+	printf("Commands (%lu):\n\n", shell->cmd_count);
 	i = 0;
-	while (i < cmd_count)
+	while (i < shell->cmd_count)
 	{
 		print_command(current_command, i);
 		current_command = current_command->next;
@@ -99,22 +90,6 @@ void	print_parsed_data(t_shell *shell)
 	}
 }
 
-static size_t	cmd_lstlen(t_cmd *cmd)
-{
-	size_t	i;
-	t_cmd	*current;
-
-	if (cmd == NULL)
-		return (0);
-	i = 1;
-	current = cmd->next;
-	while (current != cmd)
-	{
-		i++;
-		current = current->next;
-	}
-	return (i);
-}
 
 /*
 **	Start minishell, provide the prompt, read input and execute commands
@@ -138,9 +113,9 @@ static void	minishell(t_shell *shell)
 			continue ;
 		if (shell->cmd != NULL)
 		{
-			prepare_execution(shell, cmd_lstlen(shell->cmd));
-			dispatch(shell, cmd_lstlen(shell->cmd));
-			postpare_execution(shell, cmd_lstlen(shell->cmd));
+			prepare_execution(shell);
+			dispatch(shell);
+			postpare_execution(shell);
 		}
 	}
 	rl_clear_history();


### PR DESCRIPTION
This PR fixes exit's behaviour in subshells. It shouldn't output anything if ran in a subshell (pipeline).

Count cmds during prepare_execution and use that value instead of all manually calculated / passed `cmd_count` values.

closes #25