### PR TITLE
fix: fix incorrect command parsing and broken pipeline, add flags for…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/01/05 17:52:33 by dplotzl           #+#    #+#              #
-#    Updated: 2025/02/27 14:15:05 by xgossing         ###   ########.fr        #
+#    Updated: 2025/03/01 15:11:23 by dplotzl          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -30,6 +30,7 @@ SRC		=	helper/alloc.c \
 			helper/error.c \
 			helper/expander_utils.c \
 			helper/init.c \
+			helper/parser_utils.c \
 			helper/signal.c \
 			helper/token_utils.c \
 			parsing/cmd_parser.c \

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/27 20:55:43 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/01 15:10:05 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -113,6 +113,7 @@ typedef struct s_cmd
 	int							fd_in;
 	int							fd_out;
 	pid_t						child_pid;
+	bool						skip;
 	struct s_cmd				*next;
 	struct s_cmd				*prev;
 }								t_cmd;
@@ -123,6 +124,7 @@ typedef struct s_tok
 	char						*file;
 	t_t_typ						type;
 	bool						is_quoted;
+	bool						first_cmd;
 	struct s_tok				*next;
 	struct s_tok				*prev;
 }								t_tok;
@@ -242,6 +244,9 @@ int								handle_heredoc(t_shell *shell,
 
 // --------------  init  -------------------------------------------------- //
 bool							init_shell(t_shell *shell, char **env);
+
+// --------------  parser_utils  ------------------------------------------ //
+int								validate_tokens(t_tok *tokens);
 
 // --------------  signal  ------------------------------------------------ //
 void							handle_sigint(int sig);

--- a/src/execution/builtin.c
+++ b/src/execution/builtin.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 21:51:59 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/26 19:46:03 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/01 15:16:11 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,6 +53,8 @@ void	execute_single_builtin(t_shell *shell, t_b_typ type)
 {
 	void	(*builtin)(t_shell *, t_cmd *);
 
+	if (shell->cmd->skip)
+		return ;
 	shell->fd_copies[STDIN_FILENO] = dup(STDIN_FILENO);
 	if (shell->fd_copies[STDIN_FILENO] == -1)
 	{

--- a/src/execution/execute.c
+++ b/src/execution/execute.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 17:26:32 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/27 20:56:24 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/01 15:14:00 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,6 +54,8 @@ void	execute_command(t_shell *shell, t_cmd *command)
 // TODO: unify into one function
 static void	execute_without_pipeline(t_shell *shell)
 {
+	if (shell->cmd->skip)
+		return ;
 	shell->cmd->child_pid = fork();
 	if (shell->cmd->child_pid == -1)
 		error_exit(shell, NO_FORK, "execute_without_pipeline", EXIT_FAILURE);

--- a/src/execution/pipeline.c
+++ b/src/execution/pipeline.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 21:54:23 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/27 20:49:49 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/01 15:15:21 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,6 +74,8 @@ void	execute_with_pipeline(t_shell *shell, t_cmd *command, int *pipe_fd)
 
 	prev_fd = -2;
 	i = 0;
+	if (!command)
+		return ;
 	while (i < shell->cmd_count)
 	{
 		if (i < shell->cmd_count - 1 && pipe(pipe_fd) == -1)

--- a/src/helper/parser_utils.c
+++ b/src/helper/parser_utils.c
@@ -1,0 +1,43 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parser_utils.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/01 15:06:36 by dplotzl           #+#    #+#             */
+/*   Updated: 2025/03/01 15:09:59 by dplotzl          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static int	invalid_pipes(t_tok *token)
+{
+	if (token->type == PIPE)
+	{
+		if (token->prev && token->prev->type == PIPE)
+			return (error(END_PIPE, 2));
+		else if (token->next->type == PIPE)
+			return (error(CONSEC_PIPES, 2));
+	}
+	return (0);
+}
+
+int	validate_tokens(t_tok *token)
+{
+	t_tok	*current;
+
+	current = token;
+	if (current->type == PIPE)
+		return (error(START_PIPE, 2));
+	while (current)
+	{
+		if (invalid_pipes(current))
+			return (2);
+		current = current->next;
+		if (current == token)
+			break ;
+	}
+	return (0);
+}

--- a/src/helper/token_utils.c
+++ b/src/helper/token_utils.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/09 15:46:52 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/27 19:02:56 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/01 15:31:53 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -86,9 +86,9 @@ static	t_tok	*init_token(t_shell *shell, char *content, t_t_typ type)
 	if (!token)
 		error_exit(shell, NO_MEM, "init_token", EXIT_FAILURE);
 	token->content = content;
-	token->file = NULL;
 	token->type = type;
 	token->is_quoted = false;
+	token->first_cmd = false;
 	token->next = NULL;
 	token->prev = NULL;
 	return (token);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:48:13 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/27 20:56:10 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/01 15:42:58 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,6 +45,7 @@ static void	print_command(t_cmd *command, size_t num)
 			i++;
 		}
 	}
+	printf("Skip: %d\n", command->skip);
 	printf("FD_in: %d\n", command->fd_in);
 	printf("FD_out: %d\n", command->fd_out);
 	printf("(end of command %lu)\n\n", num + 1);
@@ -90,6 +91,50 @@ void	print_parsed_data(t_shell *shell)
 	}
 }
 
+static void	print_tab(char **tab)
+{
+	int	i;
+
+	if (!(tab))
+	{
+		printf("NULL");
+		return ;
+	}
+	i = 0;
+	printf("[");
+	while (tab[i])
+	{
+		printf("%s", tab[i]);
+		if (tab[i + 1])
+			printf(", ");
+		i++;
+	}
+	printf("]");
+}
+
+void	print_cmd(t_cmd *cmd)
+{
+	t_cmd	*tmp;
+
+	tmp = cmd;
+	if (!cmd)
+	{
+		printf("No command\n");
+		return ;
+	}
+	while (tmp->next != cmd)
+	{
+		printf("Skip -> %d, fd_in -> %d, fd_out -> %d, cmd : ",
+		tmp->skip, tmp->fd_in, tmp->fd_out);
+		print_tab(tmp->args);
+		printf("\n");
+		tmp = tmp->next;
+	}
+	printf("Skip -> %d, fd_in -> %d, fd_out -> %d, cmd : ",
+		 tmp->skip, tmp->fd_in, tmp->fd_out);
+	print_tab(tmp->args);
+	printf("\n");
+}
 
 /*
 **	Start minishell, provide the prompt, read input and execute commands
@@ -111,6 +156,7 @@ static void	minishell(t_shell *shell)
 		add_history(shell->cmd_input);
 		if (!tokenize_input(shell, shell->cmd_input))
 			continue ;
+		print_cmd(shell->cmd);
 		if (shell->cmd != NULL)
 		{
 			prepare_execution(shell);

--- a/src/parsing/cmd_redir.c
+++ b/src/parsing/cmd_redir.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/06 23:19:30 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/26 01:44:57 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/01 15:50:12 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -96,6 +96,20 @@ static bool	process_redirection(t_shell *shell, t_cmd *cmd, t_tok *token)
 	int	*fd;
 	int	new_fd;
 
+	if (cmd == NULL)
+	{
+		if (token->type == HEREDOC)
+			new_fd = handle_heredoc(shell, token->next->content);
+		else
+			new_fd = open_redirection_file(token->next->content, token->type);
+		if (new_fd == -1)
+		{
+			return (error_cmd(shell, token->next->content), false);
+			return (false);
+		}
+		close(new_fd);
+		return (true);
+	}
 	if (token->type == REDIR_IN || token->type == HEREDOC)
 		fd = &cmd->fd_in;
 	else if (token->type == REDIR_OUT || token->type == REDIR_APPEND)
@@ -108,6 +122,7 @@ static bool	process_redirection(t_shell *shell, t_cmd *cmd, t_tok *token)
 		new_fd = open_redirection_file(token->next->content, token->type);
 	if (new_fd == -1)
 	{
+		cmd->skip = true;
 		error_cmd(shell, token->next->content);
 		return (false);
 	}

--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 20:37:00 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/28 00:56:05 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/01 15:55:06 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -88,9 +88,12 @@ static bool	handle_expansion(t_shell *shell, char **output, char *input,
 /*
 **	Helper to check if the dollar sign should trigger variable expansion:
 **	The function performs the following checks:
-** 	- Returns false if '$' is preceded by an alphanumeric character (e.g., 'VAR$USER').
-** 	- Returns false if '$' appears inside single quotes ('''), as they prevent expansion.
-** 	- Detects if '$' is used within a heredoc ('<<') and determines if expansion should occur:
+** 	- Returns false if '$' is preceded 
+		by an alphanumeric character (e.g., 'VAR$USER').
+** 	- Returns false if '$' appears inside single quotes ('''), 
+		as they prevent expansion.
+** 	- Detects if '$' is used within a heredoc ('<<') and determines 
+		if expansion should occur:
 ** 	  - If the heredoc delimiter is quoted ('<< "$VAR"'), expansion is prevented.
 ** 	  - If the heredoc delimiter is unquoted ('<< VAR'), expansion is allowed.
 ** 	- Returns true for '$?', as it should always be expanded.
@@ -98,7 +101,8 @@ static bool	handle_expansion(t_shell *shell, char **output, char *input,
 ** 	- Returns false if the environment variable does not exist.
 */
 
-static bool	should_expand_dollar(t_shell *shell, char *input, int i, bool s_quote)
+static bool	should_expand_dollar(t_shell *shell, char *input, int i,
+									bool s_quote)
 {
 	int	j;
 	int	k;
@@ -108,10 +112,11 @@ static bool	should_expand_dollar(t_shell *shell, char *input, int i, bool s_quot
 	if (i > 0 && ft_isalnum(input[i - 1]))
 		return (false);
 	j = i - 1;
-	while (j > 0 && (ft_isblank(input[j]) || input[j] == '"' || input[j] == '\''))
+	while (j > 0 && (ft_isblank(input[j]) || input[j] == '"'
+			|| input[j] == '\''))
 		j--;
 	if ((j == 1 && input[j] == '<' && input[j - 1] == '<')
-			|| (j > 1 && input[j] == '<' && input[j - 1] == '<'))
+		|| (j > 1 && input[j] == '<' && input[j - 1] == '<'))
 	{
 		k = j + 2;
 		while (input[k] && ft_isblank(input[k]))

--- a/src/parsing/token.c
+++ b/src/parsing/token.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 12:41:04 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/27 19:10:38 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/01 14:47:55 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -103,20 +103,6 @@ static bool	extract_token_content(t_shell *shell, t_tok **lst, char **input)
 }
 
 /*
-**	Handle consecutive pipes
-*/
-
-static bool	validate_pipe_syntax(t_tok *prev_token, t_tok **lst)
-{
-	if (*lst && prev_token && prev_token->type == PIPE
-		&& (*lst)->prev->type == PIPE)
-	{
-		return (error(CONSEC_PIPES, false));
-	}
-	return (true);
-}
-
-/*
 **	Core function to tokenize user input in a structured token list.
 *	1. Check for invalid starting pipe.
 **	2. Skip leading whitespace.
@@ -128,14 +114,9 @@ static bool	validate_pipe_syntax(t_tok *prev_token, t_tok **lst)
 
 bool	tokenize(t_shell *shell, t_tok **lst, char *input)
 {
-	t_tok	*prev_token;
-
 	if (!lst || !input)
 		return (false);
 	*lst = NULL;
-	prev_token = NULL;
-	if (*input == '|')
-		return (error(START_PIPE, false));
 	while (*input)
 	{
 		while (ft_isblank(*input))
@@ -144,12 +125,12 @@ bool	tokenize(t_shell *shell, t_tok **lst, char *input)
 			break ;
 		if (!extract_token_content(shell, lst, &input))
 			return (false);
-		if (!validate_pipe_syntax(prev_token, lst))
-			return (false);
-		if (*lst)
-			prev_token = (*lst)->prev;
+		if ((*lst)->type == CMD)
+			(*lst)->first_cmd = true;
+		if ((*lst)->type == PIPE)
+			(*lst)->first_cmd = false;
 	}
-	if (prev_token && prev_token->type == PIPE)
+	if ((*lst)->prev && (*lst)->prev->type == PIPE)
 		return (error(END_PIPE, false));
 	return (true);
 }

--- a/src/parsing/tokenizer.c
+++ b/src/parsing/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 21:08:39 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/23 09:44:45 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/01 15:10:22 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -112,6 +112,8 @@ bool	tokenize_input(t_shell *shell, char *input)
 		return (false);
 	if (invalid_redirection(shell->tokens))
 		return (error_token(shell, shell->tokens));
+	if (validate_tokens(shell->tokens))
+		return (false);
 	if (!parse_commands(shell))
 		return (false);
 	return (true);


### PR DESCRIPTION
This pull request includes several changes to the `minishell` project, focusing on adding new functionality, improving error handling, and updating various files. The most important changes include the addition of the `skip` attribute to the `t_cmd` struct, the introduction of the `validate_tokens` function, and modifications to command execution to respect the `skip` attribute.

### New Functionality:
* Added `skip` attribute to `t_cmd` and `first_cmd` attribute to `t_tok` structs in `inc/minishell.h` to manage command execution flow. [[1]](diffhunk://#diff-71ac2db5fec65368c16ab9fc572b50749d817e528958ff7471446e3ece847671R116) [[2]](diffhunk://#diff-71ac2db5fec65368c16ab9fc572b50749d817e528958ff7471446e3ece847671R127)
* Introduced `validate_tokens` function in `src/helper/parser_utils.c` to validate token sequences and handle errors related to pipes. [[1]](diffhunk://#diff-71ac2db5fec65368c16ab9fc572b50749d817e528958ff7471446e3ece847671R248-R250) [[2]](diffhunk://#diff-7f28e36c712f33a2ef0168ad7d1e5c2913c75af77f5e2f52bc2fc3f642f7f408R1-R43)

### Command Execution:
* Updated `execute_single_builtin` and `execute_without_pipeline` functions to respect the `skip` attribute, preventing execution of invalid commands. [[1]](diffhunk://#diff-dd5a4f44337352f7e7f724a86fd0f9de6bb33464c0a687c82d489cf5f121442cR56-R57) [[2]](diffhunk://#diff-f9e4569482e83527a5547cdcadda26dad0e25526222b15e63bc4cc7ac928b9cfR57-R58)
* Added checks in `execute_with_pipeline` to handle cases where the command is null.

### Error Handling:
* Modified `skip_invalid_command` and `is_command_start` functions to correctly set the `skip` attribute and handle invalid commands. [[1]](diffhunk://#diff-7866653935da223db09b4b7d67303b971cfe311ac437738540e6992bcb1e45e9R76-R81) [[2]](diffhunk://#diff-7866653935da223db09b4b7d67303b971cfe311ac437738540e6992bcb1e45e9R97-R106)
* Enhanced `process_redirection` function to handle redirection errors more gracefully when the command is null.

### Miscellaneous:
* Added `parser_utils.c` to the `SRC` list in the `Makefile`.
* Updated various header comments across multiple files to reflect the latest modification dates. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L9-R9) [[2]](diffhunk://#diff-71ac2db5fec65368c16ab9fc572b50749d817e528958ff7471446e3ece847671L9-R9) [[3]](diffhunk://#diff-dd5a4f44337352f7e7f724a86fd0f9de6bb33464c0a687c82d489cf5f121442cL9-R9) [[4]](diffhunk://#diff-f9e4569482e83527a5547cdcadda26dad0e25526222b15e63bc4cc7ac928b9cfL9-R9) [[5]](diffhunk://#diff-1a6b744d72a389190e63e22634ec0e1c013dc088ffee9779999bd7bd019dcba9L9-R9) [[6]](diffhunk://#diff-7866653935da223db09b4b7d67303b971cfe311ac437738540e6992bcb1e45e9L9-R9) [[7]](diffhunk://#diff-14b70ba9110826ab0ebb112d35abcf25541ffe181c84235b6ca4affbb6231d28L9-R9) [[8]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L9-R9) [[9]](diffhunk://#diff-ef3c15648da97ea93bc9b88b8eda454b9c38b1096c087aa4ed5cde6ef193c475L9-R9) [[10]](diffhunk://#diff-7b015f699cd1a3e2f7b8d9f203d474edda941a2da9f7f414dea25f827e2cce34L9-R9)… first command and skip command

### **Closes the issues:**
- https://github.com/idoyoga/mshell/issues/19
- https://github.com/idoyoga/mshell/issues/21
- https://github.com/idoyoga/mshell/issues/22