### PR TITLE
fix: various small issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ libft/libft.a
 minishell
 tmp*
 compile_commands.json
+.ccls-cache/

--- a/src/builtins/cd.c
+++ b/src/builtins/cd.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:56:21 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/27 14:25:22 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/02 15:23:25 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,12 +20,19 @@ static void	change_directory(t_shell *shell, char *directory)
 	if (!working_directory)
 	{
 		// handle critical error
+		ft_putstr_fd("cd: ", STDERR_FILENO);
+		ft_putstr_fd(directory, STDERR_FILENO);
+		ft_putstr_fd(": ", STDERR_FILENO);
+		ft_putendl_fd(strerror(errno), STDERR_FILENO);
 		return ;
 	}
 	if (chdir(directory) != 0)
 	{
 		free(working_directory);
-		printf("cd: %s: %s\n", directory, strerror(errno));
+		ft_putstr_fd("cd: ", STDERR_FILENO);
+		ft_putstr_fd(directory, STDERR_FILENO);
+		ft_putstr_fd(": ", STDERR_FILENO);
+		ft_putendl_fd(strerror(errno), STDERR_FILENO);
 		shell->status = 1;
 		return ;
 	}

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:54:56 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/27 20:38:54 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/02 15:20:46 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,8 @@ static bool	is_valid_exit_arg(char *arg)
 	int	i;
 
 	i = 0;
+	if (arg == NULL)
+		return (false);
 	if (arg[i] == '\0')
 		return (false);
 	if (arg[i] == '-' || arg[i] == '+')
@@ -35,7 +37,7 @@ void	builtin_exit(t_shell *shell, t_cmd *cmd)
 	size_t	count;
 
 	if (shell->cmd_count == 1)
-		printf("exit\n");
+		ft_putendl_fd("exit", STDERR_FILENO);
 	count = count_cmd_args(cmd);
 	if (count == 1)
 	{
@@ -47,7 +49,7 @@ void	builtin_exit(t_shell *shell, t_cmd *cmd)
 		error_exit(shell, EXIT_INVALID_ARGUMENT, "exit", 2);
 	}
 	if (count > 1)
-		shell->status = ft_atoi(cmd->args[1]); // TODO: protect
+		shell->status = ft_atoi(cmd->args[1]);
 	if (count > 2)
 	{
 		shell->status = 1;

--- a/src/builtins/export.c
+++ b/src/builtins/export.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:56:12 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/27 15:32:41 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/02 15:19:34 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,7 +60,9 @@ void	builtin_export(t_shell *shell, t_cmd *cmd)
 	{
 		if (!is_valid_identifier(cmd->args[i]))
 		{
-			printf("export: `%s': not a valid identifier\n", cmd->args[i]);
+			ft_putstr_fd("export: `", STDERR_FILENO);
+			ft_putstr_fd(cmd->args[i], STDERR_FILENO);
+			ft_putendl_fd("': not a valid identifier\n", STDERR_FILENO);
 		}
 		else
 		{

--- a/src/execution/setup.c
+++ b/src/execution/setup.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 19:55:42 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/27 20:55:00 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/02 14:56:08 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ static void	find_absolute_path(t_shell *shell, t_cmd *cmd)
 	while (shell->path_segments[i] != NULL && cmd->args != NULL)
 	{
 		cmd->cmd = ft_strjoin_three(shell->path_segments[i], "/", cmd->args[0]);
-		if (!cmd)
+		if (!cmd->cmd)
 			error_exit(shell, NO_MEM, "ft_strjoin_three", EXIT_FAILURE);
 		if (access(cmd->cmd, F_OK) == 0)
 		{

--- a/src/helper/alloc.c
+++ b/src/helper/alloc.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   alloc.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
+/*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/15 17:24:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/23 10:36:45 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/02 15:00:32 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,7 +56,10 @@ void	*alloc_tracker_add(t_alloc *tracker, void *ptr, int is_array)
 	if (tracker->count >= tracker->capacity)
 	{
 		if (!alloc_tracker_resize(tracker))
+		{
+			free(ptr);
 			error_exit(tracker->shell, NO_TRACK, NULL, EXIT_FAILURE);
+		}
 	}
 	tracker->allocs[tracker->count] = ptr;
 	tracker->is_array[tracker->count] = is_array;

--- a/src/helper/signal.c
+++ b/src/helper/signal.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   signal.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
+/*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 10:47:06 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/24 18:01:31 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/02 15:07:32 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ void	handle_sigint(int sig)
 {
 	if (sig == SIGINT)
 	{
-		g_signal = 1;
+		g_signal = sig;
 		write(1, "\n", 1);
 		rl_replace_line("", 0);
 		rl_on_new_line();
@@ -41,7 +41,7 @@ void	handle_heredoc_sigint(int sig)
 	cr = '\n';
 	if (sig == SIGINT)
 	{
-		g_signal = 1;
+		g_signal = sig;
 		ioctl(STDIN_FILENO, TIOCSTI, &cr);
 	}
 }
@@ -57,6 +57,7 @@ void	handle_sigquit(int sig)
 	cr = '\n';
 	if (sig == SIGQUIT)
 	{
+		g_signal = sig;
 		ioctl(STDIN_FILENO, TIOCSTI, &cr);
 		write(2, "Quit (core dumped)", 18);
 		exit (131);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:48:13 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/01 15:42:58 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/02 15:08:34 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -148,6 +148,8 @@ static void	minishell(t_shell *shell)
 		g_signal = 0;
 		shell->cmd_input = alloc_tracker_replace(&shell->alloc_tracker,
 				shell->cmd_input, readline(shell->prompt));
+		if (g_signal != 0)
+			shell->status = g_signal + 128;
 		if (!shell->cmd_input)
 			break ;
 		setup_signals(SIG_IGN, SIG_IGN);

--- a/src/parsing/heredoc.c
+++ b/src/parsing/heredoc.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   heredoc.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
+/*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/13 16:06:25 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/27 18:55:52 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/02 15:02:45 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,6 +75,8 @@ int	handle_heredoc(t_shell *shell, const char *delimiter)
 	static int	heredoc_count = 0;
 
 	count_str = ft_itoa(heredoc_count++);
+	if (!count_str)
+		return (-1);
 	alloc_tracker_add(&shell->alloc_tracker, count_str, 0);
 	heredoc_filename = safe_strjoin(shell, "/tmp/.heredoc_", count_str);
 	fd = open(heredoc_filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
@@ -84,8 +86,7 @@ int	handle_heredoc(t_shell *shell, const char *delimiter)
 	{
 		if (fd >= 3)
 			close(fd);
-		unlink(heredoc_filename);
-		setup_signals(handle_sigint, SIG_IGN);
+		(unlink(heredoc_filename), setup_signals(handle_sigint, SIG_IGN));
 		return (-1);
 	}
 	close(fd);


### PR DESCRIPTION
This PR includes several small changes to address open issues.
- incorrect null check after strjoin, fixes #38 
- protect itoa in heredoc against malloc failure, fixes #36 
- set status code after receiving a signal in interactive mode, fixes #34 
- print the output of `exit` and any builtin errors to STDERR instead of STDOUT, fixes #33 