### PR TITLE
feat: add barebone environment in case minishell is called with 'env -i'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/01/05 17:52:33 by dplotzl           #+#    #+#              #
-#    Updated: 2025/03/01 15:11:23 by dplotzl          ###   ########.fr        #
+#    Updated: 2025/03/02 18:08:50 by dplotzl          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -26,6 +26,7 @@ SRC		=	helper/alloc.c \
 			helper/alloc_helper.c \
 			helper/clean.c \
 			helper/cmd_utils.c \
+			helper/env_helper.c \
 			helper/env_utils.c \
 			helper/error.c \
 			helper/expander_utils.c \

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/01 15:10:05 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/02 19:47:56 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -211,13 +211,18 @@ void							skip_invalid_command(t_shell *shell,
 bool							is_command_start(t_tok *current);
 t_t_typ							determine_token_type(t_tok **lst);
 
+// --------------  env_helper  -------------------------------------------- //
+char							*get_env_value(t_shell *shell, char *key);
+char							**create_default_env(t_shell *shell);
+bool							upsert_env_variable(t_shell *shell, t_env **lst,
+									char *key, char *new_value);
+
 // --------------  env_utils  --------------------------------------------- //
 t_env							*add_env_variable(t_shell *shell, t_env **lst,
 									char *data);
 char							*create_prompt(t_shell *shell);
 bool							remove_env_variable(t_shell *shell, t_env **lst,
 									char *var_name);
-char							*get_env_value(t_shell *shell, char *key);
 
 // --------------  error  ------------------------------------------------- //
 bool							error(t_error err, int status);

--- a/src/builtins/export.c
+++ b/src/builtins/export.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:56:12 by xgossing          #+#    #+#             */
-/*   Updated: 2025/03/02 15:19:34 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/02 19:47:03 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,8 @@ static bool	is_valid_identifier(char *name)
 
 	i = 0;
 	if (!name) // should this ever happen?
+		//
+		// I guess not, as function is only called after checking command arguments.
 		return (false);
 	if (name[0] >= '0' && name[0] <= '9')
 		return (false);
@@ -50,7 +52,9 @@ void	builtin_export(t_shell *shell, t_cmd *cmd)
 {
 	size_t	argument_count;
 	size_t	i;
-	char	*tmp;
+	char	*equal_sign;
+	char	*key;
+	char	*value;
 
 	argument_count = count_cmd_args(cmd);
 	if (argument_count == 1)
@@ -58,20 +62,61 @@ void	builtin_export(t_shell *shell, t_cmd *cmd)
 	i = 1;
 	while (cmd->args[i] != NULL)
 	{
-		if (!is_valid_identifier(cmd->args[i]))
+		equal_sign = ft_strchr(cmd->args[i], '='); // find the first '=' in the argument
+		if (equal_sign) // Case: export KEY=VALUE
 		{
-			ft_putstr_fd("export: `", STDERR_FILENO);
-			ft_putstr_fd(cmd->args[i], STDERR_FILENO);
-			ft_putendl_fd("': not a valid identifier\n", STDERR_FILENO);
+			*equal_sign = '\0'; // replace '=' with '\0' to split the string
+			key = cmd->args[i];
+			value = equal_sign + 1;
+			if (is_valid_identifier(cmd->args[i]))
+				upsert_env_variable(shell, &shell->env, key, value);
+			else
+			{
+				ft_putstr_fd("export: `", STDERR_FILENO);
+				ft_putstr_fd(cmd->args[i], STDERR_FILENO);
+				ft_putendl_fd("': not a valid identifier", STDERR_FILENO);
+			}
+			*equal_sign = '='; // restore the original string
+		}
+		else if (is_valid_identifier(cmd->args[i]))
+		{
+			upsert_env_variable(shell, &shell->env, cmd->args[i], "");
 		}
 		else
 		{
-			if (!find_or_check_env(shell, cmd->args[i], NULL, true))
-			{
-				tmp = safe_strdup(shell, cmd->args[i]);
-				add_env_variable(shell, &shell->env, tmp);
-			}
+			ft_putstr_fd("export: `", STDERR_FILENO);
+			ft_putstr_fd(cmd->args[i], STDERR_FILENO);
+			ft_putendl_fd("': not a valid identifier", STDERR_FILENO);
 		}
 		i++;
 	}
 }
+/* void	builtin_export(t_shell *shell, t_cmd *cmd) */
+/* { */
+/* 	size_t	argument_count; */
+/* 	size_t	i; */
+/* 	char	*tmp; */
+
+/* 	argument_count = count_cmd_args(cmd); */
+/* 	if (argument_count == 1) */
+/* 		return (export_print(shell->env)); */
+/* 	i = 1; */
+/* 	while (cmd->args[i] != NULL) */
+/* 	{ */
+/* 		if (!is_valid_identifier(cmd->args[i])) */
+/* 		{ */
+/* 			ft_putstr_fd("export: `", STDERR_FILENO); */
+/* 			ft_putstr_fd(cmd->args[i], STDERR_FILENO); */
+/* 			ft_putendl_fd("': not a valid identifier\n", STDERR_FILENO); */
+/* 		} */
+/* 		else */
+/* 		{ */
+/* 			if (!find_or_check_env(shell, cmd->args[i], NULL, true)) */
+/* 			{ */
+/* 				tmp = safe_strdup(shell, cmd->args[i]); */
+/* 				add_env_variable(shell, &shell->env, tmp); */
+/* 			} */
+/* 		} */
+/* 		i++; */
+/* 	} */
+/* } */

--- a/src/helper/env_helper.c
+++ b/src/helper/env_helper.c
@@ -1,0 +1,94 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   env_helper.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/02 18:07:01 by dplotzl           #+#    #+#             */
+/*   Updated: 2025/03/02 19:45:49 by dplotzl          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+char	*get_env_value(t_shell *shell, char *key)
+{
+	t_env	*current;
+	size_t	len;
+
+	if (!shell | !shell->env || !key)
+		return (NULL);
+	current = shell->env;
+	len = ft_strlen(key);
+	while (current)
+	{
+		if (ft_strlen(current->data) > len && ft_strncmp(current->data, key,
+				len) == 0 && current->data[len] == '=')
+			return (current->data + len + 1);
+		current = current->next;
+		if (current == shell->env)
+			break ;
+	}
+	return (NULL);
+}
+
+/*
+**	Create a default environment with PATH and SHLVL variables in case
+**	no environment is passed.
+*/
+
+char	**create_default_env(t_shell *shell)
+{
+	char	**env;
+	char	cwd[1024];
+
+	if (!getcwd(cwd, sizeof(cwd)))
+		ft_strlcpy(cwd, "/", 2);
+	env = safe_malloc(shell, sizeof(char *) * 4);
+	if (!env)
+		return (NULL);
+	env[0] = safe_strdup(shell, "PATH=/usr/bin:/bin");
+	env[1] = safe_strdup(shell, "SHLVL=1");
+	env[2] = safe_strdup(shell, safe_strjoin(shell, "PWD=", cwd));
+	env[3] = NULL;
+	if (!env[0] || !env[1] || !env[2])
+		error_exit(shell, NO_ENV, "create_default_env", EXIT_FAILURE);
+	return (env);
+}
+
+/*
+**	Upsert an environment variable. 
+*/
+
+bool	upsert_env_variable(t_shell *shell, t_env **lst, char *key, char *new_value)
+{
+	t_env	*node;
+	char	*updated_value;
+	int		len;
+
+	if (!lst || !*lst || !key || !new_value)
+		return (false);
+	if (find_or_check_env(shell, key, NULL, true))
+	{
+		node = *lst;
+		while (node)
+		{
+			len = match_env_variable(key, node->data);
+			if (len > 0)
+			{
+				updated_value = safe_strjoin(shell, key, "=");
+				updated_value = safe_strjoin(shell, updated_value, new_value);
+				node->data = updated_value;
+				return (true);
+			}
+			node = node->next;
+			if (node == *lst)
+				break ;
+		}
+	}
+	updated_value = safe_strjoin(shell, key, "=");
+	updated_value = safe_strjoin(shell, updated_value, new_value);
+	return (add_env_variable(shell, lst, updated_value) != NULL);
+}
+

--- a/src/helper/env_utils.c
+++ b/src/helper/env_utils.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/11 09:36:20 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/27 16:04:25 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/02 18:08:27 by dplotzl          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -82,7 +82,7 @@ char	*create_prompt(t_shell *shell)
 		return (NULL);
 	shell->home_dir = getenv("HOME");
 	if (!shell->home_dir)
-		return (error(NO_HOME, 0), NULL);
+		shell->home_dir = safe_strdup(shell, "");
 	len = ft_strlen(shell->home_dir);
 	work_dir = shell->work_dir;
 	if (ft_strlen(work_dir) > len && work_dir[len] == '/'
@@ -145,25 +145,4 @@ bool	remove_env_variable(t_shell *shell, t_env **lst, char *var_name)
 			break ;
 	}
 	return (false);
-}
-
-char	*get_env_value(t_shell *shell, char *key)
-{
-	t_env	*current;
-	size_t	len;
-
-	if (!shell | !shell->env || !key)
-		return (NULL);
-	current = shell->env;
-	len = ft_strlen(key);
-	while (current)
-	{
-		if (ft_strlen(current->data) > len && ft_strncmp(current->data, key,
-				len) == 0 && current->data[len] == '=')
-			return (current->data + len + 1);
-		current = current->next;
-		if (current == shell->env)
-			break ;
-	}
-	return (NULL);
 }


### PR DESCRIPTION
This pull request includes several changes to improve environment variable handling and initialization in the minishell project. The most important changes include the addition of new helper functions for environment management, updates to the `export` builtin command, and modifications to the initialization process to handle cases where no environment is passed.

### Environment Management Improvements:
* Added new helper functions `get_env_value`, `create_default_env`, and `upsert_env_variable` in `src/helper/env_helper.c` to manage environment variables more effectively.
* Updated `Makefile` to include `helper/env_helper.c` in the source files.

### Export Builtin Command Updates:
* Refactored `builtin_export` function in `src/builtins/export.c` to handle `KEY=VALUE` pairs and use the new `upsert_env_variable` function.

### Initialization Process Enhancements:
* Modified the `init_env` function in `src/helper/init.c` to create a default environment if none is passed.
* Updated the `init_work_dirs` function in `src/helper/init.c` to handle cases with incomplete environments.

### Code Cleanup:
* Removed duplicate `get_env_value` function from `src/helper/env_utils.c`.
* Simplified the initialization process by removing redundant code and ensuring proper order of function calls.