### PR TITLE
fix(heredoc): abort command on SIGINT

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/02 22:01:02 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/02 23:35:53 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -161,6 +161,7 @@ typedef struct s_shell
 	size_t cmd_count;      // Number of distinct commands (subshells)
 	int env_count;         // Environment variable count
 	int status;            // Exit status
+	bool abort;            // Whether to abort a whole execution cycle (for heredoc signal)
 	char *prompt;          // Prompt string
 	char *cmd_input;       // Command input
 	char *home_dir;        // Home directory

--- a/src/execution/utils.c
+++ b/src/execution/utils.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 17:02:32 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/27 15:09:10 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/02 22:26:42 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,12 +33,17 @@ char	**get_env_array(t_shell *shell)
 	return (envp);
 }
 
+// second if checks might not even be necessary
+// if there's a '/', bash always seems to treat it as a path
+// and look for it in the current working directory
 inline bool	is_path(char *str)
 {
 	if (!str)
 		return (false);
 	if (str[0] == '/' || ft_strncmp("./", str, 2) == 0 || ft_strncmp("../", str,
 			3) == 0)
+		return (true);
+	if (ft_strchr(str, '/') != NULL)
 		return (true);
 	return (false);
 }

--- a/src/helper/init.c
+++ b/src/helper/init.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/04 12:12:50 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/02 19:51:00 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/02 21:25:47 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,8 +75,8 @@ static bool	init_env(t_shell *shell, char **env)
 static bool	init_work_dirs(t_shell *shell)
 {
 	char	*cwd;
-	/* char	*tmp; */
 
+	/* char	*tmp; */
 	/* tmp = safe_strdup(shell, "OLDPWD"); */
 	/* if (!tmp) */
 	/* 	return (error(NO_MEM, false)); */
@@ -149,5 +149,6 @@ bool	init_shell(t_shell *shell, char **env)
 		return (error(NO_PROMPT, false));
 	shell->fd_copies[0] = -2;
 	shell->fd_copies[1] = -2;
+	shell->abort = false;
 	return (true);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:48:13 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/02 15:08:34 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/02 21:15:59 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -146,6 +146,7 @@ static void	minishell(t_shell *shell)
 	{
 		setup_signals(handle_sigint, SIG_IGN);
 		g_signal = 0;
+		shell->abort = false;
 		shell->cmd_input = alloc_tracker_replace(&shell->alloc_tracker,
 				shell->cmd_input, readline(shell->prompt));
 		if (g_signal != 0)
@@ -159,7 +160,7 @@ static void	minishell(t_shell *shell)
 		if (!tokenize_input(shell, shell->cmd_input))
 			continue ;
 		print_cmd(shell->cmd);
-		if (shell->cmd != NULL)
+		if (shell->cmd != NULL && !shell->abort)
 		{
 			prepare_execution(shell);
 			dispatch(shell);

--- a/src/parsing/cmd_parser.c
+++ b/src/parsing/cmd_parser.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/23 21:15:51 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/01 15:44:35 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/02 23:27:52 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -159,7 +159,7 @@ bool	parse_commands(t_shell *shell)
 	shell->cmd = NULL;
 	current = shell->tokens;
 	redirected = false;
-	while (current != shell->tokens || !shell->cmd)
+	while ((current != shell->tokens || !shell->cmd) && !shell->abort)
 	{
 		if (!process_token(shell, &current, &cmd, &redirected))
 			continue ;

--- a/src/parsing/cmd_redir.c
+++ b/src/parsing/cmd_redir.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/06 23:19:30 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/02 22:02:26 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/02 22:22:32 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -104,6 +104,7 @@ static bool	process_redirection(t_shell *shell, t_cmd *cmd, t_tok *token)
 			new_fd = open_redirection_file(token->next->content, token->type);
 		if (new_fd == -1)
 		{
+			cmd->skip = true;
 			return (error_cmd(shell, token->next->content), false);
 			return (false);
 		}
@@ -150,7 +151,7 @@ bool	handle_redirection(t_shell *shell, t_tok *token, t_cmd *cmd)
 			|| current->type == REDIR_OUT || current->type == REDIR_APPEND)
 		{
 			if (!process_redirection(shell, cmd, current))
-				break ;
+				return (false);
 			current = current->next;
 		}
 		current = current->next;

--- a/src/parsing/heredoc.c
+++ b/src/parsing/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/13 16:06:25 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/02 22:10:04 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/02 22:22:36 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,6 +58,12 @@ static bool	heredoc_read_input(t_shell *shell, const char *delimiter, int fd,
 		ft_putendl_fd(line, fd);
 	}
 	setup_signals(handle_sigint, SIG_IGN);
+	if (g_signal != 0)
+	{
+		shell->status = g_signal + 128;
+		shell->abort = true;
+		return (false);
+	}
 	return (true);
 }
 


### PR DESCRIPTION
This PR includes two small fixes to here-document.

- Abort the full command when a here-document is interrupted by a signal
- Set the correct status code when a here-document is interrupted by a signal