### PR TITLE
feat(parsing, execution): handle NOOP & access err

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/02 23:35:53 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/03 16:19:00 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -96,8 +96,20 @@ typedef enum e_error
 	PWD_NO_CWD,
 	CD_TOO_MANY_ARGUMENTS,
 	CD_NO_HOME,
+	EXEC_NOT_FOUND,
+	EXEC_IS_DIRECTORY,
+	EXEC_PERMISSION_DENIED,
 	TOTAL
 }								t_error;
+
+typedef enum e_access_status
+{
+	A_NOOP,      // no command to run, do nothing
+	A_NOT_FOUND, // doesn't exist at all
+	A_PERMISSION_DENIED,
+	A_IS_DIRECTORY,
+	A_CAN_EXECUTE
+}								t_acc_t;
 
 typedef enum e_quoted_status
 {
@@ -117,8 +129,10 @@ typedef struct s_cmd
 {
 	char						*cmd;
 	char						**args;
+	int							argc;
 	int							fd_in;
 	int							fd_out;
+	t_acc_t						access_status;
 	pid_t						child_pid;
 	bool						skip;
 	struct s_cmd				*next;
@@ -131,6 +145,7 @@ typedef struct s_tok
 	char						*file;
 	t_t_typ						type;
 	bool						is_quoted;
+	bool						is_null;
 	bool						first_cmd;
 	struct s_tok				*next;
 	struct s_tok				*prev;

--- a/src/builtins/dispatch.c
+++ b/src/builtins/dispatch.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 19:14:39 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/13 11:14:05 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/03 00:23:51 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,8 @@ t_b_typ	identify_builtin(char *str)
 	char	*builtin_name;
 
 	i = 0;
+	if (!str)
+		return (_NOT_A_BUILTIN);
 	while (i < g_builtin_count)
 	{
 		builtin_name = g_builtins[i].name;

--- a/src/execution/execute.c
+++ b/src/execution/execute.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 17:26:32 by xgossing          #+#    #+#             */
-/*   Updated: 2025/03/01 15:14:00 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/03 00:49:19 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,13 +34,31 @@ void	execute_command(t_shell *shell, t_cmd *command)
 {
 	t_b_typ	type;
 
+	shell->status = 0;
 	signal(SIGINT, SIG_DFL);
 	signal(SIGQUIT, SIG_DFL);
 	redirect_command(shell, command);
-	if (!command->args || !command->args[0])
+	if (command->access_status == A_NOOP)
 	{
+		ft_putendl_fd("nooping the heck out",2);
 		clean_shell(shell);
 		exit(0);
+	}
+	if (command->access_status == A_NOT_FOUND)
+	{
+		shell->status = 127;
+		error_exit(shell, EXEC_NOT_FOUND, "execute_command", shell->status);
+	}
+	if (command->access_status == A_IS_DIRECTORY)
+	{
+		shell->status = 126;
+		error_exit(shell, EXEC_IS_DIRECTORY, "execute_command", shell->status);
+	}
+	if (command->access_status == A_PERMISSION_DENIED)
+	{
+		shell->status = 126;
+		error_exit(shell, EXEC_PERMISSION_DENIED, "execute_command",
+			shell->status);
 	}
 	type = identify_builtin(command->args[0]);
 	if (type > _NOT_A_BUILTIN)
@@ -72,6 +90,8 @@ void	dispatch(t_shell *shell)
 	int		pipe_fd[2];
 	t_b_typ	type;
 
+	shell->status = 0;
+	printf("cmd count: %lu\n", shell->cmd_count);
 	if (shell->cmd_count != 1)
 	{
 		pipe_fd[0] = -2;

--- a/src/helper/error.c
+++ b/src/helper/error.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/26 18:09:55 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/02/28 01:06:46 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/03 00:53:54 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -130,5 +130,8 @@ static const char	*g_error_msgs[TOTAL] = {
 	"Too many arguments",
 	"Too many arguments",
 	"HOME not set",
-	"Failed to run getcwd"
+	"Failed to run getcwd",
+	"Command not found",
+	"Is a directory",
+	"Permission denied"
 };

--- a/src/helper/token_utils.c
+++ b/src/helper/token_utils.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/09 15:46:52 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/02 22:10:43 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/03 00:14:23 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -85,6 +85,7 @@ static t_tok	*init_token(t_shell *shell, char *content, t_t_typ type)
 	token->content = content;
 	token->type = type;
 	token->is_quoted = false;
+	token->is_null = false;
 	token->first_cmd = false;
 	token->next = NULL;
 	token->prev = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:48:13 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/02 21:15:59 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/03 15:45:21 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -124,8 +124,8 @@ void	print_cmd(t_cmd *cmd)
 	}
 	while (tmp->next != cmd)
 	{
-		printf("Skip -> %d, fd_in -> %d, fd_out -> %d, cmd : ",
-		tmp->skip, tmp->fd_in, tmp->fd_out);
+		printf("Skip -> %d, fd_in -> %d, fd_out -> %d, count -> %d, cmd : ",
+		tmp->skip, tmp->fd_in, tmp->fd_out, tmp->argc);
 		print_tab(tmp->args);
 		printf("\n");
 		tmp = tmp->next;

--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 20:37:00 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/02 21:53:06 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/03 00:14:06 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -227,6 +227,7 @@ void	xpand(t_shell *shell, t_tok *token)
 	if (is_empty_variable(shell, token->content))
 	{
 		token->content = NULL;
+		token->is_null = true;
 		return ;
 	}
 	i = 0;

--- a/src/parsing/heredoc.c
+++ b/src/parsing/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/13 16:06:25 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/02 22:22:36 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/03 15:59:47 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -81,6 +81,7 @@ int	handle_heredoc(t_shell *shell, const char *delimiter, bool is_quoted)
 	char		*heredoc_filename;
 	static int	heredoc_count = 0;
 
+	printf("heredoc looking for `%s`\n", delimiter);
 	count_str = ft_itoa(heredoc_count++);
 	if (!count_str)
 		return (-1);


### PR DESCRIPTION
This PR includes several major changes to the command parser, as well as the execution pipeline. It refactors the command parser (cmd_parser.c) to properly handle empty commands (i.e. commands consisting of only empty variables, or that only have redirections but no arguments).