### PR TITLE
fix(parser): fix repeating heredocs

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:48:13 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/03 15:45:21 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/03 17:02:31 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -151,8 +151,10 @@ static void	minishell(t_shell *shell)
 				shell->cmd_input, readline(shell->prompt));
 		if (g_signal != 0)
 			shell->status = g_signal + 128;
-		if (!shell->cmd_input)
+		if (!shell->cmd_input) {
+			ft_putendl_fd("exit", 2);
 			break ;
+		}
 		setup_signals(SIG_IGN, SIG_IGN);
 		if (blank_line(shell->cmd_input))
 			continue ;

--- a/src/parsing/cmd_parser.c
+++ b/src/parsing/cmd_parser.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/23 21:15:51 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/03 16:28:23 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/03 18:18:57 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,7 +37,7 @@ static int	count_args(t_shell *shell, t_tok *token)
 			i++;
 		current = current->next;
 	}
-	printf("counted %d args\n", i);
+	// printf("counted %d args\n", i);
 	return (i);
 }
 
@@ -80,7 +80,6 @@ static bool	process_token(t_shell *shell, t_tok **token, t_cmd **cmd,
 	}
 	if ((*token)->type > END && (*token)->type < PIPE)
 	{
-		printf("redirection for %s\n", (*token)->content);
 		if (!(*redir))
 		{
 			if (!handle_redirection(shell, *token, *cmd))
@@ -88,11 +87,9 @@ static bool	process_token(t_shell *shell, t_tok **token, t_cmd **cmd,
 				(*cmd)->skip = true;
 				return (false);
 			}
-			if ((*token)->type != HEREDOC)
-				*redir = true;
+			*redir = true;
 		}
 		*token = (*token)->next;
-		// skip the extra redirection token
 	}
 	else if ((*token)->type > PIPE && !(*token)->is_null)
 	{

--- a/src/parsing/cmd_redir.c
+++ b/src/parsing/cmd_redir.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/06 23:19:30 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/02 22:22:32 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/03 18:18:38 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -99,7 +99,8 @@ static bool	process_redirection(t_shell *shell, t_cmd *cmd, t_tok *token)
 	if (cmd == NULL)
 	{
 		if (token->type == HEREDOC)
-			new_fd = handle_heredoc(shell, token->next->content, token->next->is_quoted);
+			new_fd = handle_heredoc(shell, token->next->content,
+					token->next->is_quoted);
 		else
 			new_fd = open_redirection_file(token->next->content, token->type);
 		if (new_fd == -1)
@@ -118,7 +119,8 @@ static bool	process_redirection(t_shell *shell, t_cmd *cmd, t_tok *token)
 	else
 		return (false);
 	if (token->type == HEREDOC)
-		new_fd = handle_heredoc(shell, token->next->content, token->next->is_quoted);
+		new_fd = handle_heredoc(shell, token->next->content,
+				token->next->is_quoted);
 	else
 		new_fd = open_redirection_file(token->next->content, token->type);
 	if (new_fd == -1)
@@ -147,8 +149,14 @@ bool	handle_redirection(t_shell *shell, t_tok *token, t_cmd *cmd)
 	current = token;
 	while (current && current->type != PIPE)
 	{
-		if (current->type == REDIR_IN || current->type == HEREDOC
-			|| current->type == REDIR_OUT || current->type == REDIR_APPEND)
+		if (!cmd->skip && (current->type == REDIR_IN
+				|| current->type == REDIR_OUT || current->type == REDIR_APPEND))
+		{
+			if (!process_redirection(shell, cmd, current))
+				cmd->skip = true;
+			current = current->next;
+		}
+		else if (current->type == HEREDOC)
 		{
 			if (!process_redirection(shell, cmd, current))
 				return (false);

--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 20:37:00 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/03 00:14:06 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/03 18:08:04 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -278,13 +278,10 @@ bool	expand_dilla_variables(t_shell *shell)
 				&& current_token->prev->type != ARG
 				&& current_token->prev->type != PIPE))
 		{
-			printf("not expanding %s\n", current_token->content);
 		}
 		else
 		{
-			printf("expanding %s\n", current_token->content);
 			xpand(shell, current_token);
-			printf("expanded to %s\n", current_token->content);
 		}
 		current_token = current_token->next;
 		if (current_token == shell->tokens)


### PR DESCRIPTION
This PR includes small changes to how parse_commands handles here-documents and redirections. Previously, multiple here-docs in a subshell would cause subsequent delimiters to be requested again. This is addressed by adding a separate clause in process_redirection(), and always setting `redir` to true after it returns.

Additionally prints 'exit' to STDERR if the main readline receives EOF (Ctrl-D)

fixes #47 
fixes #48 