### PR TITLE
fix(export): fix duplicate and erroneous exports

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/03 16:19:00 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/03 19:11:07 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -271,6 +271,7 @@ int								match_env_variable(char *var_name,
 bool							append_char_to_str(t_shell *shell,
 									char **output, int *index, char *c);
 bool							is_quote(char c);
+bool							is_valid_var_char(char c, size_t index);
 
 // --------------  heredoc  ----------------------------------------------- //
 int								handle_heredoc(t_shell *shell,

--- a/src/builtins/export.c
+++ b/src/builtins/export.c
@@ -6,31 +6,11 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:56:12 by xgossing          #+#    #+#             */
-/*   Updated: 2025/03/02 19:47:03 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/03 19:10:35 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-
-static bool	is_valid_identifier(char *name)
-{
-	size_t	i;
-
-	i = 0;
-	if (!name) // should this ever happen?
-		//
-		// I guess not, as function is only called after checking command arguments.
-		return (false);
-	if (name[0] >= '0' && name[0] <= '9')
-		return (false);
-	while (name[i] != '\0' && name[i] != '=')
-	{
-		if (!ft_isalnum(name[i]) && name[i] != '_')
-			return (false);
-		i++;
-	}
-	return (true);
-}
 
 static void	export_print(t_env *env)
 {
@@ -48,13 +28,48 @@ static void	export_print(t_env *env)
 	}
 }
 
+static bool	has_valid_key(char *token)
+{
+	size_t	i;
+
+	if (!token[0] || token[0] == '=')
+		return (false);
+	i = 0;
+	while (token[i] && token[i] != '=')
+	{
+		if (!is_valid_var_char(token[i], i))
+			return (false);
+		i++;
+	}
+	return (true);
+}
+
+static void	export_goods(t_shell *shell, char *data)
+{
+	char	*equal_sign;
+	char	*key;
+	char	*value;
+
+	equal_sign = ft_strchr(data, '=');
+	if (equal_sign == NULL)
+	{
+		if (!env_variable_exists(shell, data))
+			add_env_variable(shell, &shell->env, safe_strdup(shell, data));
+	}
+	else
+	{
+		*equal_sign = '\0';
+		key = data;
+		value = equal_sign + 1;
+		upsert_env_variable(shell, &shell->env, key, value);
+		*equal_sign = '=';
+	}
+}
+
 void	builtin_export(t_shell *shell, t_cmd *cmd)
 {
 	size_t	argument_count;
 	size_t	i;
-	char	*equal_sign;
-	char	*key;
-	char	*value;
 
 	argument_count = count_cmd_args(cmd);
 	if (argument_count == 1)
@@ -62,61 +77,16 @@ void	builtin_export(t_shell *shell, t_cmd *cmd)
 	i = 1;
 	while (cmd->args[i] != NULL)
 	{
-		equal_sign = ft_strchr(cmd->args[i], '='); // find the first '=' in the argument
-		if (equal_sign) // Case: export KEY=VALUE
-		{
-			*equal_sign = '\0'; // replace '=' with '\0' to split the string
-			key = cmd->args[i];
-			value = equal_sign + 1;
-			if (is_valid_identifier(cmd->args[i]))
-				upsert_env_variable(shell, &shell->env, key, value);
-			else
-			{
-				ft_putstr_fd("export: `", STDERR_FILENO);
-				ft_putstr_fd(cmd->args[i], STDERR_FILENO);
-				ft_putendl_fd("': not a valid identifier", STDERR_FILENO);
-			}
-			*equal_sign = '='; // restore the original string
-		}
-		else if (is_valid_identifier(cmd->args[i]))
-		{
-			upsert_env_variable(shell, &shell->env, cmd->args[i], "");
-		}
-		else
+		if (!has_valid_key(cmd->args[i]))
 		{
 			ft_putstr_fd("export: `", STDERR_FILENO);
 			ft_putstr_fd(cmd->args[i], STDERR_FILENO);
 			ft_putendl_fd("': not a valid identifier", STDERR_FILENO);
 		}
+		else
+		{
+			export_goods(shell, cmd->args[i]);
+		}
 		i++;
 	}
 }
-/* void	builtin_export(t_shell *shell, t_cmd *cmd) */
-/* { */
-/* 	size_t	argument_count; */
-/* 	size_t	i; */
-/* 	char	*tmp; */
-
-/* 	argument_count = count_cmd_args(cmd); */
-/* 	if (argument_count == 1) */
-/* 		return (export_print(shell->env)); */
-/* 	i = 1; */
-/* 	while (cmd->args[i] != NULL) */
-/* 	{ */
-/* 		if (!is_valid_identifier(cmd->args[i])) */
-/* 		{ */
-/* 			ft_putstr_fd("export: `", STDERR_FILENO); */
-/* 			ft_putstr_fd(cmd->args[i], STDERR_FILENO); */
-/* 			ft_putendl_fd("': not a valid identifier\n", STDERR_FILENO); */
-/* 		} */
-/* 		else */
-/* 		{ */
-/* 			if (!find_or_check_env(shell, cmd->args[i], NULL, true)) */
-/* 			{ */
-/* 				tmp = safe_strdup(shell, cmd->args[i]); */
-/* 				add_env_variable(shell, &shell->env, tmp); */
-/* 			} */
-/* 		} */
-/* 		i++; */
-/* 	} */
-/* } */

--- a/src/helper/env_helper.c
+++ b/src/helper/env_helper.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env_helper.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dplotzl <dplotzl@student.42vienna.com>     +#+  +:+       +#+        */
+/*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 18:07:01 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/02 19:45:49 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/03 19:04:44 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,10 +58,11 @@ char	**create_default_env(t_shell *shell)
 }
 
 /*
-**	Upsert an environment variable. 
+**	Upsert an environment variable.
 */
 
-bool	upsert_env_variable(t_shell *shell, t_env **lst, char *key, char *new_value)
+bool	upsert_env_variable(t_shell *shell, t_env **lst, char *key,
+		char *new_value)
 {
 	t_env	*node;
 	char	*updated_value;
@@ -91,4 +92,3 @@ bool	upsert_env_variable(t_shell *shell, t_env **lst, char *key, char *new_value
 	updated_value = safe_strjoin(shell, updated_value, new_value);
 	return (add_env_variable(shell, lst, updated_value) != NULL);
 }
-

--- a/src/helper/expander_utils.c
+++ b/src/helper/expander_utils.c
@@ -6,11 +6,20 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 20:39:27 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/02 21:35:29 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/03 19:09:58 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+bool	is_valid_var_char(char c, size_t index)
+{
+	if (c == '_')
+		return (true);
+	if (index == 0)
+		return (ft_isalpha(c));
+	return (ft_isalnum(c));
+}
 
 /*
 **	Check if var_name matches the name of an environment variable inside

--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -6,20 +6,11 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 20:37:00 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/03 18:08:04 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/03 19:10:16 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-
-static bool	is_valid_var_char(char c, size_t index)
-{
-	if (c == '_')
-		return (true);
-	if (index == 0)
-		return (ft_isalpha(c));
-	return (ft_isalnum(c));
-}
 
 /*
 **	Expand a given environment variable ($VAR) by replacing it with its value.


### PR DESCRIPTION
This PR includes a major refactor of the `export` builtin, fixing several issue.

### Fixed:
- `export foo` when `foo` is already exported turns it into NULL
- `export =` causes duplicate `=` values to be inserted into the environment

Any other previous issues related to `export` should now also be fixed.

fixes #42 