### PR TITLE
fix: status codes and other things

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/03 19:45:00 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 12:36:40 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -98,6 +98,7 @@ typedef enum e_error
 	CD_TOO_MANY_ARGUMENTS,
 	CD_NO_HOME,
 	EXEC_NOT_FOUND,
+	EXEC_NO_FILE,
 	EXEC_IS_DIRECTORY,
 	EXEC_PERMISSION_DENIED,
 	TOTAL
@@ -251,10 +252,16 @@ bool							remove_env_variable(t_shell *shell, t_env **lst,
 
 // --------------  error  ------------------------------------------------- //
 bool							error(t_error err, int status);
+bool							error_context(t_error err, char *context,
+									int status);
 void							error_exit(t_shell *shell, t_error err,
 									char *context, int status);
+void							error_exit_s(t_shell *shell, t_error err,
+									char *context, int status);
 bool							error_token(t_shell *shell, t_tok *token);
-void							error_cmd(t_shell *shell, const char *cmd_name);
+void							strerror_cmd(const char *cmd_name);
+void							error_cmd_str(const char *command,
+									const char *message);
 
 // --------------  expander  ---------------------------------------------- //
 bool							expand_dollar_variables(t_shell *shell,
@@ -295,8 +302,6 @@ bool							tokenize(t_shell *shell, t_tok **lst,
 									char *input);
 
 // --------------  tokenizer  --------------------------------------------- //
-char							*trim_quotes(t_shell *shell, char *src,
-									int len);
 void							update_quote_state(bool *d_quote, bool *s_quote,
 									char c);
 bool							tokenize_input(t_shell *shell, char *input);

--- a/src/builtins/cd.c
+++ b/src/builtins/cd.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:56:21 by xgossing          #+#    #+#             */
-/*   Updated: 2025/03/03 19:39:26 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 00:49:48 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,6 +40,7 @@ static void	change_directory(t_shell *shell, char *directory)
 	// set new PWD
 	// update shell prompt
 	// set success status code?
+	shell->status = 0;
 	free(working_directory);
 }
 

--- a/src/builtins/echo.c
+++ b/src/builtins/echo.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:54:38 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/13 14:54:41 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 00:49:36 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,7 +65,6 @@ void	builtin_echo(t_shell *shell, t_cmd *cmd)
 	int		arg_index;
 	bool	has_n;
 
-	(void)shell;
 	has_n = has_n_flag(cmd->args);
 	arg_index = 1;
 	if (has_n)
@@ -79,6 +78,7 @@ void	builtin_echo(t_shell *shell, t_cmd *cmd)
 	}
 	if (!has_n)
 		printf("\n");
+	shell->status = 0;
 	// else
 	// 	fflush(STDOUT_FILENO); // fflush is not allowed,
 	// however without printing a newline, printf won't flush by itself

--- a/src/builtins/env.c
+++ b/src/builtins/env.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:56:17 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/27 15:11:47 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 00:50:15 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,4 +26,5 @@ void	builtin_env(t_shell *shell, t_cmd *cmd)
 		if (current == shell->env)
 			break ;
 	}
+	shell->status = 0;
 }

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:54:56 by xgossing          #+#    #+#             */
-/*   Updated: 2025/03/02 15:20:46 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 12:43:29 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,28 +32,26 @@ static bool	is_valid_exit_arg(char *arg)
 	return (true);
 }
 
+// TODO: handle extreme overflow (9223372036854775808, treat as non-number (2)))
 void	builtin_exit(t_shell *shell, t_cmd *cmd)
 {
 	size_t	count;
 
 	if (shell->cmd_count == 1)
-		ft_putendl_fd("exit", STDERR_FILENO);
+		ft_putendl_fd("exit", STDOUT_FILENO);
 	count = count_cmd_args(cmd);
 	if (count == 1)
-	{
-		clean_shell(shell);
-		exit(shell->status);
-	}
+		(clean_shell(shell), exit(shell->status));
 	if (!is_valid_exit_arg(cmd->args[1]))
-	{
-		error_exit(shell, EXIT_INVALID_ARGUMENT, "exit", 2);
-	}
+		error_exit_s(shell, EXIT_INVALID_ARGUMENT, "exit", 2);
 	if (count > 1)
+	{
 		shell->status = ft_atoi(cmd->args[1]);
+	}
 	if (count > 2)
 	{
 		shell->status = 1;
-		error(EXIT_TOO_MANY_ARGUMENTS, 1); // TODO: add context to error()?
+		error_context(EXIT_TOO_MANY_ARGUMENTS, "exit", 1);
 		return ;
 	}
 	clean_shell(shell);

--- a/src/builtins/export.c
+++ b/src/builtins/export.c
@@ -6,12 +6,13 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:56:12 by xgossing          #+#    #+#             */
-/*   Updated: 2025/03/03 19:10:35 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 10:26:49 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
+// TODO: value should be enclosed in double quotes KEY="VALUE"
 static void	export_print(t_env *env)
 {
 	t_env	*current;
@@ -71,6 +72,7 @@ void	builtin_export(t_shell *shell, t_cmd *cmd)
 	size_t	argument_count;
 	size_t	i;
 
+	shell->status = 0;
 	argument_count = count_cmd_args(cmd);
 	if (argument_count == 1)
 		return (export_print(shell->env));
@@ -82,11 +84,10 @@ void	builtin_export(t_shell *shell, t_cmd *cmd)
 			ft_putstr_fd("export: `", STDERR_FILENO);
 			ft_putstr_fd(cmd->args[i], STDERR_FILENO);
 			ft_putendl_fd("': not a valid identifier", STDERR_FILENO);
+			shell->status = 1;
 		}
 		else
-		{
 			export_goods(shell, cmd->args[i]);
-		}
 		i++;
 	}
 }

--- a/src/builtins/pwd.c
+++ b/src/builtins/pwd.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:55:44 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/26 20:32:22 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 00:50:40 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,4 +22,5 @@ void	builtin_pwd(t_shell *shell, t_cmd *cmd)
 		error_exit(shell, PWD_NO_CWD, "getcwd", EXIT_FAILURE);
 	printf("%s\n", path);
 	free(path);
+	shell->status = 0;
 }

--- a/src/builtins/unset.c
+++ b/src/builtins/unset.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:56:08 by xgossing          #+#    #+#             */
-/*   Updated: 2025/02/27 14:34:00 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 00:50:53 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,4 +33,5 @@ void	builtin_unset(t_shell *shell, t_cmd *cmd)
 		}
 		i++;
 	}
+	shell->status = 0;
 }

--- a/src/execution/builtin.c
+++ b/src/execution/builtin.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 21:51:59 by xgossing          #+#    #+#             */
-/*   Updated: 2025/03/01 15:16:11 by dplotzl          ###   ########.fr       */
+/*   Updated: 2025/03/04 03:19:27 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@
 // also close STDOUT_COPY when first dup2 fails?
 // what could cause it to fail, what's the situation then
 // and can we recover at all?
+// TODO: inspect
 static void	reset_io(int *fd_copies)
 {
 	if (dup2(fd_copies[STDIN_FILENO], STDIN_FILENO) == -1)
@@ -54,7 +55,10 @@ void	execute_single_builtin(t_shell *shell, t_b_typ type)
 	void	(*builtin)(t_shell *, t_cmd *);
 
 	if (shell->cmd->skip)
+	{
+		shell->status = 1;
 		return ;
+	}
 	shell->fd_copies[STDIN_FILENO] = dup(STDIN_FILENO);
 	if (shell->fd_copies[STDIN_FILENO] == -1)
 	{

--- a/src/execution/setup.c
+++ b/src/execution/setup.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 19:55:42 by xgossing          #+#    #+#             */
-/*   Updated: 2025/03/03 16:20:54 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 00:22:30 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,8 @@ static t_acc_t	get_file_access_status(const char *path)
 	if (S_ISDIR(file_stat.st_mode))
 		return (A_IS_DIRECTORY);
 	if (access(path, X_OK) == -1)
+		return (A_PERMISSION_DENIED);
+	if (!(file_stat.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)))
 		return (A_PERMISSION_DENIED);
 	return (A_CAN_EXECUTE);
 }

--- a/src/helper/error.c
+++ b/src/helper/error.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/26 18:09:55 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/03 19:38:00 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 12:10:24 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@ static const char	*g_error_msgs[TOTAL];
 /*
 **	Print an error message to stderr and return true if status is not 0.
 **	- If error code is valid, print 'minishell: ' followed by the corresponding
-**	  error message from 'g_error_msgs' to stderr.
+**		error message from 'g_error_msgs' to stderr.
 **	- Return 'true' if 'status != 0', otherwise return 'false'.
 */
 
@@ -26,6 +26,20 @@ bool	error(t_error err, int status)
 	if (err < 0 || err >= TOTAL)
 		return (false);
 	ft_putstr_fd("minishell: ", 2);
+	ft_putendl_fd((char *)g_error_msgs[err], 2);
+	return (status != 0);
+}
+
+bool	error_context(t_error err, char *context, int status)
+{
+	if (err < 0 || err >= TOTAL)
+		return (false);
+	ft_putstr_fd("minishell: ", 2);
+	if (context && *context)
+	{
+		ft_putstr_fd(context, 2);
+		ft_putstr_fd(": ", 2);
+	}
 	ft_putendl_fd((char *)g_error_msgs[err], 2);
 	return (status != 0);
 }
@@ -57,10 +71,26 @@ void	error_exit(t_shell *shell, t_error err, char *context, int status)
 	exit(status);
 }
 
+void	error_exit_s(t_shell *shell, t_error err, char *context, int status)
+{
+	if (err < 0 || err >= TOTAL)
+		return ;
+	ft_putstr_fd("minishell: ", 2);
+	if (context && *context)
+	{
+		ft_putstr_fd(context, 2);
+		ft_putstr_fd(": ", 2);
+	}
+	ft_putendl_fd((char *)g_error_msgs[err], 2);
+	if (shell)
+		clean_shell(shell);
+	exit(status);
+}
+
 /*
 **	Print a syntax error message for an unexpected token
 **	1. If the next token is `shell->tokens` (indicating the end of input),
-**	   it prints `newline`, signaling a missing argument.
+**		it prints `newline`, signaling a missing argument.
 **	2. Otherwise, it prints the unexpected token's content.
 */
 
@@ -78,15 +108,26 @@ bool	error_token(t_shell *shell, t_tok *token)
 **	Print an error message for a command that failed to execute.
 */
 
-void	error_cmd(t_shell *shell, const char *cmd_name)
+void	strerror_cmd(const char *cmd_name)
 {
 	char	*err_msg;
 
 	err_msg = ft_strjoin_four("minishell: ", cmd_name, ": ", strerror(errno));
-	alloc_tracker_add(&shell->alloc_tracker, err_msg, 0);
 	if (!err_msg)
 		error(NO_MEM, false);
 	ft_putendl_fd(err_msg, 2);
+	free(err_msg);
+}
+
+void	error_cmd_str(const char *command, const char *message)
+{
+	char	*err_msg;
+
+	err_msg = ft_strjoin_four("minishell: ", command, ": ", message);
+	if (!err_msg)
+		error(NO_MEM, false);
+	ft_putendl_fd(err_msg, 2);
+	free(err_msg);
 }
 
 /*
@@ -95,43 +136,42 @@ void	error_cmd(t_shell *shell, const char *cmd_name)
 **	- Each message corresponds to an enum error code ('t_error').
 */
 
-static const char	*g_error_msgs[TOTAL] = {
-	"Too many arguments (max 1)",
-	"Shell initialization failed",
-	"Memory allocation failed",
-	"Failed to initialize environment",
-	"Failed to get current working directory",
-	"Failed to get working directory",
-	"Failed to create prompt",
-	"Failed to get user",
-	"Failed to get home directory",
-	"Failed to add allocation",
-	"Quotes not closed",
-	"Failed to resize allocation tracker",
-	"Failed to initialize allocation tracker",
-	"Input cannot start with pipe",
-	"Input cannot end with pipe",
-	"Consecutive pipes not allowed",
-	"Consecutive redirections not allowed",
-	"No command to execute",
-	"Backslash is not interpreted",
-	"Semicolon is not interpreted",
-	"Failed to open file",
-	"Syntax error",
-	"Invalid redirection type",
-	"Pointer not found in allocation tracker",
-	"Failed to expand variable",
-	"Pipe could not be acquired",
-	"File descriptor could not be duplicated (2)",
-	"Execution unsuccessful",
-	"Waiting for subprocess unsuccessful",
-	"Fork unsuccessful",
-	"Numeric argument required",
-	"Too many arguments",
-	"Failed to run getcwd",
-	"Too many arguments",
-	"HOME not set",
-	"Command not found",
-	"Is a directory",
-	"Permission denied"
-};
+static const char	*g_error_msgs[TOTAL] = {"Too many arguments (max 1)",
+											"Shell initialization failed",
+											"Memory allocation failed",
+											"Failed to initialize environment",
+											"Failed to get current working directory",
+											"Failed to get working directory",
+											"Failed to create prompt",
+											"Failed to get user",
+											"Failed to get home directory",
+											"Failed to add allocation",
+											"Quotes not closed",
+											"Failed to resize allocation tracker",
+											"Failed to initialize allocation tracker",
+											"Input cannot start with pipe",
+											"Input cannot end with pipe",
+											"Consecutive pipes not allowed",
+											"Consecutive redirections not allowed",
+											"No command to execute",
+											"Backslash is not interpreted",
+											"Semicolon is not interpreted",
+											"Failed to open file",
+											"Syntax error",
+											"Invalid redirection type",
+											"Pointer not found in allocation tracker",
+											"Failed to expand variable",
+											"Pipe could not be acquired",
+											"File descriptor could not be duplicated (2)",
+											"Execution unsuccessful",
+											"Waiting for subprocess unsuccessful",
+											"Fork unsuccessful",
+											"Numeric argument required",
+											"too many arguments",
+											"Failed to run getcwd",
+											"too many arguments",
+											"HOME not set",
+											"command not found",
+											"No such file or directory",
+											"Is a directory",
+											"Permission denied"};

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:48:13 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/03 19:40:24 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 12:45:07 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -151,8 +151,9 @@ static void	minishell(t_shell *shell)
 				shell->cmd_input, readline(shell->prompt));
 		if (g_signal != 0)
 			shell->status = g_signal + 128;
-		if (!shell->cmd_input) {
-			ft_putendl_fd("exit", 2);
+		if (!shell->cmd_input)
+		{
+			ft_putendl_fd("exit", STDOUT_FILENO);
 			break ;
 		}
 		setup_signals(SIG_IGN, SIG_IGN);

--- a/src/parsing/cmd_parser.c
+++ b/src/parsing/cmd_parser.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/23 21:15:51 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/03 18:18:57 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 12:33:33 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -85,6 +85,7 @@ static bool	process_token(t_shell *shell, t_tok **token, t_cmd **cmd,
 			if (!handle_redirection(shell, *token, *cmd))
 			{
 				(*cmd)->skip = true;
+				shell->status = 1;
 				return (false);
 			}
 			*redir = true;
@@ -111,7 +112,6 @@ bool	parse_commands(t_shell *shell)
 	t_tok		*current;
 	t_cmd		*cmd;
 	bool		redirected;
-	static int	i = 0;
 
 	cmd = NULL;
 	shell->cmd = NULL;
@@ -143,8 +143,6 @@ bool	parse_commands(t_shell *shell)
 		else
 			current = current->next;
 		if (current == shell->tokens)
-			break ;
-		if (++i > 50) // debug
 			break ;
 	}
 	return (true);

--- a/src/parsing/cmd_redir.c
+++ b/src/parsing/cmd_redir.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/06 23:19:30 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/03 18:18:38 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 00:33:40 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -106,8 +106,7 @@ static bool	process_redirection(t_shell *shell, t_cmd *cmd, t_tok *token)
 		if (new_fd == -1)
 		{
 			cmd->skip = true;
-			return (error_cmd(shell, token->next->content), false);
-			return (false);
+			return (strerror_cmd(token->next->content), false);
 		}
 		close(new_fd);
 		return (true);
@@ -126,7 +125,7 @@ static bool	process_redirection(t_shell *shell, t_cmd *cmd, t_tok *token)
 	if (new_fd == -1)
 	{
 		cmd->skip = true;
-		error_cmd(shell, token->next->content);
+		strerror_cmd(token->next->content);
 		return (false);
 	}
 	if (*fd != -2)

--- a/src/parsing/token.c
+++ b/src/parsing/token.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 12:41:04 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/02 22:10:12 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 12:47:55 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -113,6 +113,7 @@ bool	tokenize(t_shell *shell, t_tok **lst, char *input)
 			return (false);
 		if ((*lst)->type == CMD)
 			(*lst)->first_cmd = true;
+		// TODO: never true? because we always check first token
 		if ((*lst)->type == PIPE)
 			(*lst)->first_cmd = false;
 	}


### PR DESCRIPTION
This PR includes several small to medium fixes, largely focused on correct status codes for builtins, parsing and execution.

### Fixes:
- Status codes for builtins and parsing errors
- '$' was expanded even if not followed by a valid variable name
- Too many quotes were removed, also fixes possible invalid read
- Syntax parser triggered error inside of quoted strings
- Some error messages