### PR TITLE
refactor(export): quote values for `export`

### DIFF
--- a/src/builtins/export.c
+++ b/src/builtins/export.c
@@ -6,13 +6,35 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:56:12 by xgossing          #+#    #+#             */
-/*   Updated: 2025/03/04 10:26:49 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 14:34:19 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-// TODO: value should be enclosed in double quotes KEY="VALUE"
+static void	print_value_in_quotes(char *key_value)
+{
+	char	*equal_sign;
+	char	*key;
+	char	*value;
+
+	if (!key_value)
+		return ;
+	equal_sign = ft_strchr(key_value, '=');
+	if (equal_sign == NULL)
+	{
+		printf("%s", key_value);
+	}
+	else
+	{
+		*equal_sign = '\0';
+		key = key_value;
+		value = equal_sign + 1;
+		printf("%s=\"%s\"", key, value);
+		*equal_sign = '=';
+	}
+}
+
 static void	export_print(t_env *env)
 {
 	t_env	*current;
@@ -22,7 +44,9 @@ static void	export_print(t_env *env)
 	current = env;
 	while (current)
 	{
-		printf("declare -x %s\n", current->data);
+		printf("declare -x ");
+		print_value_in_quotes(current->data);
+		printf("\n");
 		current = current->next;
 		if (current == env)
 			break ;

--- a/src/execution/setup.c
+++ b/src/execution/setup.c
@@ -6,15 +6,12 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 19:55:42 by xgossing          #+#    #+#             */
-/*   Updated: 2025/03/04 00:22:30 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 14:23:32 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-// TODO: reject symlinks and other stupid garbage
-// on symlink: if -1 simply print something like
-// "error encountered while traversing symbolic link"
 static t_acc_t	get_file_access_status(const char *path)
 {
 	struct stat	file_stat;

--- a/src/helper/cmd_utils.c
+++ b/src/helper/cmd_utils.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/03 12:01:30 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/03 16:21:41 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 14:23:22 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,12 +75,6 @@ void	skip_invalid_command(t_shell *shell, t_tok **current)
 {
 	if (!shell || !current || !*current)
 		return ;
-	// shell->cmd->skip = true;
-	// TODO: currently always marks the first command as skip,
-	// should instead mark the respective cmd
-	// maybe just shell->cmd->prev->skip = true;?
-	// might not be necessary at all because once we enter
-	// this function, cmd->skip should already be true
 	while (*current && (*current)->type != PIPE)
 	{
 		*current = (*current)->next;

--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 20:37:00 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/04 12:47:31 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 14:26:34 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,6 @@ static bool	expand_env_variable(t_shell *shell, char **output, char *input,
 **	Expand $?, replacing it with the exit status of the last command.
 */
 
-// TODO: just exit_failure if itoa fails
 static bool	expand_exit_status(t_shell *shell, char **output, char *input,
 		int *index)
 {
@@ -43,7 +42,7 @@ static bool	expand_exit_status(t_shell *shell, char **output, char *input,
 	(void)input;
 	status_str = ft_itoa(shell->status);
 	if (!status_str)
-		return (error(NO_MEM, false));
+		error_exit(shell, NO_MEM, "expand_exit_status", EXIT_FAILURE);
 	alloc_tracker_add(&shell->alloc_tracker, status_str, 0);
 	new_str = safe_strjoin(shell, *output, status_str);
 	*output = new_str;
@@ -247,8 +246,6 @@ void	xpand(t_shell *shell, t_tok *token)
 		{
 			expand_exit_status(shell, &expanded_content, token->content + i,
 				&i);
-			// TODO: may return false on malloc fail
-			// - perhaps just exit instead?
 		}
 		else if (quote != QUOTE_SINGLE && token->content[i] == '$'
 			&& token->content[i + 1] && is_valid_var_char(token->content[i + 1],


### PR DESCRIPTION
This PR includes a small refactor for the `export` builtin. Running `export` without any arguments now encloses set values in double-quotes.