### PR TITLE
refactor(parser): remove quotes during expansion

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/28 13:51:24 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/04 12:36:40 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 14:38:27 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -235,7 +235,6 @@ bool							handle_redirection(t_shell *shell, t_tok *token,
 t_cmd							*add_cmd(t_shell *shell, t_cmd **lst);
 void							skip_invalid_command(t_shell *shell,
 									t_tok **current);
-bool							is_command_start(t_tok *current);
 t_t_typ							determine_token_type(t_tok **lst);
 
 // --------------  env_helper  -------------------------------------------- //

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/12 18:54:56 by xgossing          #+#    #+#             */
-/*   Updated: 2025/03/04 13:31:21 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 16:09:47 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,7 +48,6 @@ static bool	is_valid_exit_arg(char *arg)
 	digits = count_digits(arg + start);
 	if (digits == -1 || digits > 19)
 		return (false);
-	printf("digits %d\n", digits);
 	if (digits == 19)
 	{
 		if (is_negative && ft_strncmp(arg + start, g_max_negative, 19) > 0)

--- a/src/helper/cmd_utils.c
+++ b/src/helper/cmd_utils.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/03 12:01:30 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/04 14:23:22 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 14:38:25 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,39 +83,6 @@ void	skip_invalid_command(t_shell *shell, t_tok **current)
 	}
 	if (*current && (*current)->type == PIPE)
 		*current = (*current)->next;
-}
-
-/*
-**	Check if the current token is the start of a new command
-**	- A command starts if the token is of type CMD.
-**	- An ARG token may also be the start of a command if:
-**		- It follows a PIPE, or
-**		- It follows a redirection which is preceded by a PIPE.
-*/
-
-bool	is_command_start(t_tok *current)
-{
-	if (!current)
-		return (false);
-	if (current->first_cmd && !current->content)
-		return (false);
-	if (current->type == CMD)
-	{
-		if (current->content == NULL || current->content[0] == '\0')
-			return (false);
-		return (true);
-	}
-	if (current->type == ARG && current->prev)
-	{
-		if (current->prev->type == REDIR_IN || current->prev->type == REDIR_OUT
-			|| current->prev->type == HEREDOC
-			|| current->prev->type == REDIR_APPEND)
-		{
-			if (current->prev->prev && current->prev->prev->type == PIPE)
-				return (true);
-		}
-	}
-	return (false);
 }
 
 /*

--- a/src/helper/error.c
+++ b/src/helper/error.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/26 18:09:55 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/04 12:10:24 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 16:06:14 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -166,7 +166,7 @@ static const char	*g_error_msgs[TOTAL] = {"Too many arguments (max 1)",
 											"Execution unsuccessful",
 											"Waiting for subprocess unsuccessful",
 											"Fork unsuccessful",
-											"Numeric argument required",
+											"numeric argument required",
 											"too many arguments",
 											"Failed to run getcwd",
 											"too many arguments",

--- a/src/parsing/quote_removal.c
+++ b/src/parsing/quote_removal.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/02 19:35:53 by xgossing          #+#    #+#             */
-/*   Updated: 2025/03/02 21:24:37 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 16:06:31 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,6 +64,8 @@ static void	strip_quotes_from_token(char *token, char *destination)
 	destination[i] = '\0';
 }
 
+// TODO: unused right now
+// quotes are removed during expansion
 bool	remove_quotes(t_shell *shell)
 {
 	t_tok	*current;

--- a/src/parsing/tokenizer.c
+++ b/src/parsing/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: xgossing <xgossing@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 21:08:39 by dplotzl           #+#    #+#             */
-/*   Updated: 2025/03/04 03:04:06 by xgossing         ###   ########.fr       */
+/*   Updated: 2025/03/04 16:08:40 by xgossing         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,17 +83,15 @@ bool	tokenize_input(t_shell *shell, char *input)
 {
 	input = shell->cmd_input;
 	if (invalid_syntax(input) || check_unclosed_quotes(shell, input))
-		return (shell->status = 2,false);
+		return (shell->status = 2, false);
 	if (!tokenize(shell, &shell->tokens, input))
-		return (shell->status = 2,false);
+		return (shell->status = 2, false);
 	if (!expand_dilla_variables(shell))
-		return (shell->status = 2,false);
+		return (shell->status = 2, false);
 	if (invalid_redirection(shell->tokens))
-		return (shell->status = 2,error_token(shell, shell->tokens));
+		return (shell->status = 2, error_token(shell, shell->tokens));
 	if (validate_tokens(shell->tokens))
 		return (shell->status = 2, false);
-	if (!remove_quotes(shell))
-		return (false);
 	if (!parse_commands(shell))
 		return (false);
 	return (true);


### PR DESCRIPTION
This PR includes a small refactor of the parsing process. Instead of stripping quotes in a distinctive step after tokenization, expansion etc., it now happens during variable expansion.